### PR TITLE
Made popup forms only open once instead of being spammable.

### DIFF
--- a/Game Spoofer.Designer.cs
+++ b/Game Spoofer.Designer.cs
@@ -112,7 +112,6 @@
             this.Controls.Add(this.LBL_TID);
             this.Name = "Game_Spoofer";
             this.Text = "Game Spoofer";
-            this.Load += new System.EventHandler(this.Game_Spoofer_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Game Spoofer.cs
+++ b/Game Spoofer.cs
@@ -19,7 +19,7 @@ namespace Xbox_Achievement_Unlocker
 {
     public partial class Game_Spoofer : Form
     {
-        private Stopwatch stopwatch;
+        private Stopwatch stopwatch = new Stopwatch();
         public Game_Spoofer()
         {
             InitializeComponent();
@@ -96,15 +96,15 @@ namespace Xbox_Achievement_Unlocker
             TXT_SpoofedGame.Text = "Currently Spoofing: N/A";
         }
 
-        private void Game_Spoofer_Load(object sender, EventArgs e)
-        {
-            stopwatch = new Stopwatch();
-        }
-
         private void SpoofingTime_Tick(object sender, EventArgs e)
         {
             LBL_Timer.Text = "For: " + string.Format("{0:hh\\:mm\\:ss}", stopwatch.Elapsed);
+        }
 
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            Hide();
+            e.Cancel = true;
         }
     }
 }

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -19,6 +19,8 @@ namespace Xbox_Achievement_Unlocker
     public partial class MainWindow : Form
     {
         public Mem m = new Mem();
+        Game_Spoofer SpoofForm = new Game_Spoofer();
+        StatsEditor StatsForm = new StatsEditor();
         bool attached = false;
         string filter1;
         string filter2;
@@ -338,13 +340,13 @@ namespace Xbox_Achievement_Unlocker
 
         private void BTN_SpoofGame_Click(object sender, EventArgs e)
         {
-            Game_Spoofer SpoofForm = new Game_Spoofer();
-            SpoofForm.Show();
+            try { SpoofForm.Show(this); }
+            catch { SpoofForm.Focus(); }
         }
         private void BTN_StatsEditor_Click(object sender, EventArgs e)
         {
-            StatsEditor StatsForm = new StatsEditor();
-            StatsForm.Show();
+            try { StatsForm.Show(this); }
+            catch { StatsForm.Focus(); }
         }
 
         private void LST_GameFilter_SelectedIndexChanged(object sender, EventArgs e)

--- a/StatsEditor.cs
+++ b/StatsEditor.cs
@@ -111,5 +111,11 @@ namespace Xbox_Achievement_Unlocker
 
 
         }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            Hide();
+            e.Cancel = true;
+        }
     }
 }


### PR DESCRIPTION
The game spoofer and stat editor forms now only open once. Now if buttons are clicked again, the open form is focused, or opened if previously hidden.