### PR TITLE
Clean up Xbox Achievement VM (In-progress), Address Xbox Challenges in games like ESO, Remove a lot of dynamics, Spoofer has own client. Reduced warning count drastically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ We love your input! We want to make contributing to this project as easy and tra
 - Proposing new features
 
 ## We Develop with Github
+
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
 Pull Requests are the best way to propose changes to the codebase. We actively welcome your pull requests if:
@@ -17,12 +18,15 @@ Pull Requests are the best way to propose changes to the codebase. We actively w
 3. They are easy to understand and check
 
 ## Any contributions you make will be under the GNU GPL License
+
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](https://choosealicense.com/licenses/gpl-3.0/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
 ## Report bugs using Github's issues
+
 We use GitHub issues to track bugs. Report a bug by [opening a new issue](https://github.com/ItsLogic/Xbox-Achievement-Unlocker/issues/new); it's that easy!
 
 ## Write bug reports with detail and background
+
 Great Bug Reports tend to have:
 
 - A quick summary and/or background

--- a/XAU/Models/GitHubResponse.cs
+++ b/XAU/Models/GitHubResponse.cs
@@ -3,3 +3,9 @@ public class EventsUpdateResponse
     public int Timestamp { get; set; }
     public string DataVersion { get; set; }
 }
+
+public class VersionResponse
+{
+    public string DownloadURL { get; set; }
+    public string LatestBuildVersion { get; set; }
+}

--- a/XAU/Models/GitHubResponse.cs
+++ b/XAU/Models/GitHubResponse.cs
@@ -1,0 +1,5 @@
+public class EventsUpdateResponse
+{
+    public int Timestamp { get; set; }
+    public string DataVersion { get; set; }
+}

--- a/XAU/Models/GitHubResponse.cs
+++ b/XAU/Models/GitHubResponse.cs
@@ -1,11 +1,11 @@
 public class EventsUpdateResponse
 {
     public int Timestamp { get; set; }
-    public string DataVersion { get; set; }
+    public string? DataVersion { get; set; }
 }
 
 public class VersionResponse
 {
-    public string DownloadURL { get; set; }
-    public string LatestBuildVersion { get; set; }
+    public string? DownloadURL { get; set; }
+    public string? LatestBuildVersion { get; set; }
 }

--- a/XAU/Models/XAUSettings.cs
+++ b/XAU/Models/XAUSettings.cs
@@ -1,7 +1,7 @@
 public class XAUSettings
 {
-  public string SettingsVersion {get; set;}
-  public string ToolVersion {get; set;}
+  public string? SettingsVersion {get; set;}
+  public string? ToolVersion {get; set;}
   public bool UnlockAllEnabled {get; set;}
   public bool AutoSpooferEnabled {get; set;}
   public bool AutoLaunchXboxAppEnabled {get; set;}

--- a/XAU/Models/XAUSettings.cs
+++ b/XAU/Models/XAUSettings.cs
@@ -1,12 +1,12 @@
 public class XAUSettings
 {
-  public string? SettingsVersion {get; set;}
-  public string? ToolVersion {get; set;}
-  public bool UnlockAllEnabled {get; set;}
-  public bool AutoSpooferEnabled {get; set;}
-  public bool AutoLaunchXboxAppEnabled {get; set;}
-  public bool FakeSignatureEnabled {get; set;}
-  public bool RegionOverride {get; set;}
-  public bool UseAcrylic {get; set;}
-  public bool PrivacyMode {get; set;}
+    public string? SettingsVersion { get; set; }
+    public string? ToolVersion { get; set; }
+    public bool UnlockAllEnabled { get; set; }
+    public bool AutoSpooferEnabled { get; set; }
+    public bool AutoLaunchXboxAppEnabled { get; set; }
+    public bool FakeSignatureEnabled { get; set; }
+    public bool RegionOverride { get; set; }
+    public bool UseAcrylic { get; set; }
+    public bool PrivacyMode { get; set; }
 }

--- a/XAU/Models/XAUSettings.cs
+++ b/XAU/Models/XAUSettings.cs
@@ -1,0 +1,12 @@
+public class XAUSettings
+{
+  public string SettingsVersion {get; set;}
+  public string ToolVersion {get; set;}
+  public bool UnlockAllEnabled {get; set;}
+  public bool AutoSpooferEnabled {get; set;}
+  public bool AutoLaunchXboxAppEnabled {get; set;}
+  public bool FakeSignatureEnabled {get; set;}
+  public bool RegionOverride {get; set;}
+  public bool UseAcrylic {get; set;}
+  public bool PrivacyMode {get; set;}
+}

--- a/XAU/Models/XboxApiRequest.cs
+++ b/XAU/Models/XboxApiRequest.cs
@@ -43,7 +43,7 @@ public class HeartbeatRequest
 public class TitleRequest
 {
     public int expiration { get; set; } = 600;
-    public string id { get; set; }
+    public string? id { get; set; }
     public string state { get; set; } = "active";
     public string sandbox { get; set; } = "RETAIL";
 }

--- a/XAU/Models/XboxApiRequest.cs
+++ b/XAU/Models/XboxApiRequest.cs
@@ -2,7 +2,7 @@
 
 public class GameTitleRequest
 {
-    public String? Pfns { get; set; }
+    public string? Pfns { get; set; }
     public List<string> TitleIds { get; set; } = new List<string>();
 }
 
@@ -18,7 +18,7 @@ public class UnlockTitleBasedAchievementRequest
     public string serviceConfigId { get; set; } = StringConstants.ZeroUid;
     public string? titleId { get; set; }
     public string? userId { get; set; }
-    public List<AchievementsArrayEntry> achievements { get; set; } new List<AchievementsArrayEntry>();
+    public List<AchievementsArrayEntry> achievements { get; set; } = new List<AchievementsArrayEntry>();
 }
 
 public class GameStat
@@ -50,5 +50,5 @@ public class TitleRequest
 
 public class GamepassProductsRequest
 {
-    public List<string> Products { get; set; }
+    public List<string> Products { get; set; } = new List<string>();
 }

--- a/XAU/Models/XboxApiRequest.cs
+++ b/XAU/Models/XboxApiRequest.cs
@@ -3,12 +3,12 @@
 public class GameTitleRequest
 {
     public String? Pfns { get; set; }
-    public List<string> TitleIds { get; set; }
+    public List<string> TitleIds { get; set; } = new List<string>();
 }
 
 public class AchievementsArrayEntry
 {
-    public string id { get; set; }
+    public string? id{ get; set; }
     public string percentComplete { get; set; } = "100";
 }
 
@@ -16,28 +16,28 @@ public class UnlockTitleBasedAchievementRequest
 {
     public string action { get; set; } = @"progressUpdate";
     public string serviceConfigId { get; set; } = StringConstants.ZeroUid;
-    public string titleId { get; set; }
-    public string userId { get; set; }
-    public List<AchievementsArrayEntry> achievements { get; set; }
+    public string? titleId { get; set; }
+    public string? userId { get; set; }
+    public List<AchievementsArrayEntry> achievements { get; set; } new List<AchievementsArrayEntry>();
 }
 
 public class GameStat
 {
     public string Name { get; set; } = "MinutesPlayed";
-    public string TitleId { get; set; }
+    public string? TitleId { get; set; }
 }
 
 public class GameStatsRequest
 {
     public string ArrangeByField { get; set; } = "xuid";
-    public List<string> Xuids { get; set; }
-    public List<GameStat> Stats { get; set; }
+    public List<string> Xuids { get; set; } = new List<string>();
+    public List<GameStat> Stats { get; set; } = new List<GameStat>();
 }
 
 
 public class HeartbeatRequest
 {
-    public List<TitleRequest> titles { get; set; }
+    public List<TitleRequest> titles { get; set; } = new List<TitleRequest>();
 }
 
 public class TitleRequest

--- a/XAU/Models/XboxApiRequest.cs
+++ b/XAU/Models/XboxApiRequest.cs
@@ -8,7 +8,7 @@ public class GameTitleRequest
 
 public class AchievementsArrayEntry
 {
-    public string? id{ get; set; }
+    public string? id { get; set; }
     public string percentComplete { get; set; } = "100";
 }
 

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -5,89 +5,133 @@
 
 public class PersonResponse
 {
-    public string Xuid { get; set; }
+    public string? Xuid { get; set; }
+
     public bool IsFavorite { get; set; }
     public bool IsFollowingCaller { get; set; }
     public bool IsFollowedByCaller { get; set; }
     public bool IsIdentityShared { get; set; }
     public DateTime? AddedDateTimeUtc { get; set; }
-    public string DisplayName { get; set; }
-    public string RealName { get; set; }
-    public string DisplayPicRaw { get; set; }
-    public string ShowUserAsAvatar { get; set; }
-    public string Gamertag { get; set; }
-    public string GamerScore { get; set; }
-    public string ModernGamertag { get; set; }
-    public string ModernGamertagSuffix { get; set; }
-    public string UniqueModernGamertag { get; set; }
-    public string XboxOneRep { get; set; }
-    public string PresenceState { get; set; }
-    public string PresenceText { get; set; }
-    public object PresenceDevices { get; set; }
+    public string? DisplayName { get; set; }
+
+    public string? RealName { get; set; }
+
+    public string? DisplayPicRaw { get; set; }
+
+    public string? ShowUserAsAvatar { get; set; }
+
+    public string? Gamertag { get; set; }
+
+    public string? GamerScore { get; set; }
+
+    public string? ModernGamertag { get; set; }
+
+    public string? ModernGamertagSuffix { get; set; }
+
+    public string? UniqueModernGamertag { get; set; }
+
+    public string? XboxOneRep { get; set; }
+
+    public string? PresenceState { get; set; }
+
+    public string? PresenceText { get; set; }
+
+    public object? PresenceDevices { get; set; }
+
     public bool IsBroadcasting { get; set; }
     public bool IsCloaked { get; set; }
     public bool IsQuarantined { get; set; }
     public bool IsXbox360Gamerpic { get; set; }
     public DateTime? LastSeenDateTimeUtc { get; set; }
-    public object Suggestion { get; set; }
-    public object Recommendation { get; set; }
-    public object Search { get; set; }
-    public object TitleHistory { get; set; }
-    public MultiplayerSummary MultiplayerSummary { get; set; }
-    public object RecentPlayer { get; set; }
-    public object Follower { get; set; }
-    public PreferredColor PreferredColor { get; set; }
-    public List<PresenceDetail> PresenceDetails { get; set; }
-    public object TitlePresence { get; set; }
-    public object TitleSummaries { get; set; }
-    public object PresenceTitleIds { get; set; }
-    public Detail Detail { get; set; }
-    public object CommunityManagerTitles { get; set; }
-    public object SocialManager { get; set; }
-    public object Broadcast { get; set; }
-    public object Avatar { get; set; }
-    public List<LinkedAccount> LinkedAccounts { get; set; }
-    public string ColorTheme { get; set; }
-    public string PreferredFlag { get; set; }
-    public List<object> PreferredPlatforms { get; set; }
+    public object? Suggestion { get; set; }
+
+    public object? Recommendation { get; set; }
+
+    public object? Search { get; set; }
+
+    public object? TitleHistory { get; set; }
+
+    public MultiplayerSummary? MultiplayerSummary { get; set; }
+    public object? RecentPlayer { get; set; }
+
+    public object? Follower { get; set; }
+
+    public PreferredColor? PreferredColor { get; set; }
+    public List<PresenceDetail> PresenceDetails { get; set; } = new List<PresenceDetail>();
+    public object? TitlePresence { get; set; }
+
+    public object? TitleSummaries { get; set; }
+
+    public object? PresenceTitleIds { get; set; }
+
+    public Detail? Detail { get; set; }
+    public object? CommunityManagerTitles { get; set; }
+
+    public object? SocialManager { get; set; }
+
+    public object? Broadcast { get; set; }
+
+    public object? Avatar { get; set; }
+
+    public List<LinkedAccount> LinkedAccounts { get; set; } = new List<LinkedAccount>();
+    public string? ColorTheme { get; set; }
+
+    public string? PreferredFlag { get; set; }
+
+    public List<object> PreferredPlatforms { get; set; } = new List<object>();
 }
 
 public class MultiplayerSummary
 {
-    public List<object> JoinableActivities { get; set; }
-    public List<object> PartyDetails { get; set; }
+    public List<object> JoinableActivities { get; set; } = new List<object>();
+    public List<object> PartyDetails { get; set; } = new List<object>();
     public int InParty { get; set; }
 }
 
 public class PreferredColor
 {
-    public string PrimaryColor { get; set; }
-    public string SecondaryColor { get; set; }
-    public string TertiaryColor { get; set; }
+    public string? PrimaryColor { get; set; }
+
+    public string? SecondaryColor { get; set; }
+
+    public string? TertiaryColor { get; set; }
+
 }
 
 public class PresenceDetail
 {
     public bool IsBroadcasting { get; set; }
-    public string Device { get; set; }
-    public object DeviceSubType { get; set; }
-    public object GameplayType { get; set; }
-    public string PresenceText { get; set; }
-    public string State { get; set; }
-    public string TitleId { get; set; }
-    public object TitleType { get; set; }
+    public string? Device { get; set; }
+
+    public object? DeviceSubType { get; set; }
+
+    public object? GameplayType { get; set; }
+
+    public string? PresenceText { get; set; }
+
+    public string? State { get; set; }
+
+    public string? TitleId { get; set; }
+
+    public object? TitleType { get; set; }
+
     public bool IsPrimary { get; set; }
     public bool IsGame { get; set; }
-    public object RichPresenceText { get; set; }
+    public object? RichPresenceText { get; set; }
+
 }
 
 public class Detail
 {
-    public string AccountTier { get; set; }
-    public string Bio { get; set; }
+    public string? AccountTier { get; set; }
+
+    public string? Bio { get; set; }
+
     public bool IsVerified { get; set; }
-    public string Location { get; set; }
-    public string Tenure { get; set; }
+    public string? Location { get; set; }
+
+    public string? Tenure { get; set; }
+
     public List<string> Watermarks { get; set; } = new List<string>();
     public bool Blocked { get; set; }
     public bool Mute { get; set; }
@@ -98,46 +142,69 @@ public class Detail
 
 public class LinkedAccount
 {
-    public string NetworkName { get; set; }
-    public string DisplayName { get; set; }
+    public string? NetworkName { get; set; }
+
+    public string? DisplayName { get; set; }
+
     public bool ShowOnProfile { get; set; }
     public bool IsFamilyFriendly { get; set; }
-    public string Deeplink { get; set; }
+    public string? Deeplink { get; set; }
+
 }
 
 public class Profile
 {
     public List<PersonResponse> People { get; set; } = new List<PersonResponse>();
-    public object RecommendationSummary { get; set; }
-    public object FriendFinderState { get; set; }
-    public object AccountLinkDetails { get; set; }
+    public object? RecommendationSummary { get; set; }
+
+    public object? FriendFinderState { get; set; }
+
+    public object? AccountLinkDetails { get; set; }
+
 }
 
 
 public class XboxTitle
 {
-    public string TitleId { get; set; }
-    public string Pfn { get; set; }
-    public string BingId { get; set; }
-    public string WindowsPhoneProductId { get; set; }
-    public string Name { get; set; }
-    public string Type { get; set; }
-    public List<string> Devices { get; set; }
-    public string DisplayImage { get; set; }
-    public string MediaItemType { get; set; }
-    public string ModernTitleId { get; set; }
+    public string? TitleId { get; set; }
+
+    public string? Pfn { get; set; }
+
+    public string? BingId { get; set; }
+
+    public string? WindowsPhoneProductId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Type { get; set; }
+
+    public List<string> Devices { get; set; } = new List<string>();
+    public string? DisplayImage { get; set; }
+
+    public string? MediaItemType { get; set; }
+
+    public string? ModernTitleId { get; set; }
+
     public bool IsBundle { get; set; }
-    public BasicAchievementDetails Achievement { get; set; }
-    public Stats Stats { get; set; }
-    public GamePass GamePass { get; set; }
-    public object Images { get; set; }
-    public object TitleHistory { get; set; }
-    public object TitleRecord { get; set; }
-    public object Detail { get; set; }
-    public object FriendsWhoPlayed { get; set; }
-    public object AlternateTitleIds { get; set; }
-    public object ContentBoards { get; set; }
-    public string XboxLiveTier { get; set; }
+    public BasicAchievementDetails? Achievement { get; set; }
+    public Stats? Stats { get; set; }
+    public GamePass? GamePass { get; set; }
+    public object? Images { get; set; }
+
+    public object? TitleHistory { get; set; }
+
+    public object? TitleRecord { get; set; }
+
+    public object? Detail { get; set; }
+
+    public object? FriendsWhoPlayed { get; set; }
+
+    public object? AlternateTitleIds { get; set; }
+
+    public object? ContentBoards { get; set; }
+
+    public string? XboxLiveTier { get; set; }
+
 }
 
 public class BasicAchievementDetails
@@ -162,21 +229,24 @@ public class GamePass
 
 public class GameTitle
 {
-    public string Xuid { get; set; }
-    public List<XboxTitle> Titles { get; set; }
+    public string? Xuid { get; set; }
+
+    public List<XboxTitle> Titles { get; set; } = new List<XboxTitle>();
 }
 
 public class GamepassData
 {
-    public string GamepassMembership { get; set; }
+    public string? GamepassMembership { get; set; }
+
 }
 
 public class Gamepass
 {
     // This json response is actually massive, but we don't care
     // TOOD: maybe we want to look at points/stuff later
-    public string GamepassMembership { get; set; }
-    public GamepassData Data { get; set; }
+    public string? GamepassMembership { get; set; }
+
+    public GamepassData? Data { get; set; }
 }
 
 public class TitleHistory
@@ -188,49 +258,74 @@ public class TitleHistory
 
 public class Title
 {
-    public string TitleId { get; set; }
-    public string Pfn { get; set; }
-    public string BingId { get; set; }
-    public string ServiceConfigId { get; set; }
-    public string WindowsPhoneProductId { get; set; }
-    public string Name { get; set; }
-    public string Type { get; set; }
+    public string? TitleId { get; set; }
+
+    public string? Pfn { get; set; }
+
+    public string? BingId { get; set; }
+
+    public string? ServiceConfigId { get; set; }
+
+    public string? WindowsPhoneProductId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Type { get; set; }
+
     public List<string> Devices { get; set; }
-    public string DisplayImage { get; set; }
-    public string MediaItemType { get; set; }
-    public string ModernTitleId { get; set; }
+    public string? DisplayImage { get; set; }
+
+    public string? MediaItemType { get; set; }
+
+    public string? ModernTitleId { get; set; }
+
     public bool IsBundle { get; set; }
     public BasicAchievementDetails Achievement { get; set; }
-    public object Stats { get; set; }
-    public object GamePass { get; set; }
-    public object Images { get; set; }
+    public object? Stats { get; set; }
+
+    public object? GamePass { get; set; }
+
+    public object? Images { get; set; }
+
     public TitleHistory TitleHistory { get; set; }
-    public object TitleRecord { get; set; }
-    public object Detail { get; set; }
-    public object FriendsWhoPlayed { get; set; }
-    public object AlternateTitleIds { get; set; }
-    public object ContentBoards { get; set; }
-    public string XboxLiveTier { get; set; }
+    public object? TitleRecord { get; set; }
+
+    public object? Detail { get; set; }
+
+    public object? FriendsWhoPlayed { get; set; }
+
+    public object? AlternateTitleIds { get; set; }
+
+    public object? ContentBoards { get; set; }
+
+    public string? XboxLiveTier { get; set; }
+
 }
 
 public class TitlesList
 {
-    public string Xuid { get; set; }
+    public string? Xuid { get; set; }
+
     public List<Title> Titles { get; set; }
 }
 
 public class ProfileSettings
 {
-    public string Id { get; set; }
-    public string Value { get; set; }
+    public string? Id { get; set; }
+
+    public string? Value { get; set; }
+
 }
 
 public class ProfileUser
 {
-    public string Id { get; set; }
-    public string HostId { get; set; }
+    public string? Id { get; set; }
+
+    public string? HostId { get; set; }
+
     public List<ProfileSettings> Settings { get; set; }
-    public string IsSponsoredUser { get; set; }
+    public string? IsSponsoredUser { get; set; }
+
 }
 
 public class BasicProfile
@@ -242,19 +337,27 @@ public class BasicProfile
 public class Stat
 {
     public Dictionary<string, object> GroupProperties { get; set; }
-    public string Xuid { get; set; }
-    public string Scid { get; set; }
-    public string TitleId { get; set; }
-    public string Name { get; set; }
-    public string Type { get; set; }
-    public string Value { get; set; }
+    public string? Xuid { get; set; }
+
+    public string? Scid { get; set; }
+
+    public string? TitleId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Type { get; set; }
+
+    public string? Value { get; set; }
+
     public Dictionary<string, object> Properties { get; set; }
 }
 
 public class StatListCollection
 {
-    public string ArrangeByField { get; set; }
-    public string ArrangeByFieldId { get; set; }
+    public string? ArrangeByField { get; set; }
+
+    public string? ArrangeByFieldId { get; set; }
+
     public List<Stat> Stats { get; set; }
 }
 
@@ -266,53 +369,74 @@ public class GameStatsResponse
 
 public class AchievementRewards
 {
-    public string name { get; set; }
-    public string description { get; set; }
-    public string value { get; set; }
-    public string type { get; set; }
+    public string? name { get; set; }
+
+    public string? description { get; set; }
+
+    public string? value { get; set; }
+
+    public string? type { get; set; }
+
     public MediaAssets mediaAsset { get; set; }
-    public string valueType { get; set; }
+    public string? valueType { get; set; }
+
 }
 
 public class Rarity
 {
-    public string currentCategory { get; set; }
-    public string currentPercentage { get; set; }
+    public string? currentCategory { get; set; }
+
+    public string? currentPercentage { get; set; }
+
 }
 
 public class Gamerscore
 {
-    public string currentGamerscore { get; set; }
-    public string totalGamerscore { get; set; }
+    public string? currentGamerscore { get; set; }
+
+    public string? totalGamerscore { get; set; }
+
 }
 
 public class AchievementRequirements
 {
-    public string id { get; set; }
-    public string current { get; set; }
-    public string target { get; set; }
-    public string operationType { get; set; }
-    public string valueType { get; set; }
-    public string ruleParticipationType { get; set; }
+    public string? id { get; set; }
+
+    public string? current { get; set; }
+
+    public string? target { get; set; }
+
+    public string? operationType { get; set; }
+
+    public string? valueType { get; set; }
+
+    public string? ruleParticipationType { get; set; }
+
 }
 
 public class AchievementProgression
 {
     public List<AchievementRequirements> requirements { get; set; }
-    public string timeUnlocked { get; set; }
+    public string? timeUnlocked { get; set; }
+
 }
 
 public class TitleAssociations
 {
-    public string name { get; set; }
-    public string id { get; set; }
+    public string? name { get; set; }
+
+    public string? id { get; set; }
+
 }
 
 public class MediaAssets
 {
-    public string name { get; set; }
-    public string type { get; set; }
-    public string url { get; set; }
+    public string? name { get; set; }
+
+    public string? type { get; set; }
+
+    public string? url { get; set; }
+
 }
 
 public class AchievementEntryResponse

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -272,7 +272,7 @@ public class Title
 
     public string? Type { get; set; }
 
-    public List<string> Devices { get; set; }
+    public List<string> Devices { get; set; } = new List<string>();
     public string? DisplayImage { get; set; }
 
     public string? MediaItemType { get; set; }
@@ -280,14 +280,14 @@ public class Title
     public string? ModernTitleId { get; set; }
 
     public bool IsBundle { get; set; }
-    public BasicAchievementDetails Achievement { get; set; }
+    public BasicAchievementDetails? Achievement { get; set; }
     public object? Stats { get; set; }
 
     public object? GamePass { get; set; }
 
     public object? Images { get; set; }
 
-    public TitleHistory TitleHistory { get; set; }
+    public TitleHistory? TitleHistory { get; set; }
     public object? TitleRecord { get; set; }
 
     public object? Detail { get; set; }
@@ -306,7 +306,7 @@ public class TitlesList
 {
     public string? Xuid { get; set; }
 
-    public List<Title> Titles { get; set; }
+    public List<Title> Titles { get; set; } = new List<Title>();
 }
 
 public class ProfileSettings
@@ -323,20 +323,20 @@ public class ProfileUser
 
     public string? HostId { get; set; }
 
-    public List<ProfileSettings> Settings { get; set; }
+    public List<ProfileSettings> Settings { get; set; } = new List<ProfileSettings>();
     public string? IsSponsoredUser { get; set; }
 
 }
 
 public class BasicProfile
 {
-    public List<ProfileUser> ProfileUsers { get; set; }
+    public List<ProfileUser> ProfileUsers { get; set; } = new List<ProfileUser>();
 }
 
 
 public class Stat
 {
-    public Dictionary<string, object> GroupProperties { get; set; }
+    public Dictionary<string, object> GroupProperties { get; set; } = new Dictionary<string, object>();
     public string? Xuid { get; set; }
 
     public string? Scid { get; set; }
@@ -349,7 +349,7 @@ public class Stat
 
     public string? Value { get; set; }
 
-    public Dictionary<string, object> Properties { get; set; }
+    public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 }
 
 public class StatListCollection
@@ -358,13 +358,13 @@ public class StatListCollection
 
     public string? ArrangeByFieldId { get; set; }
 
-    public List<Stat> Stats { get; set; }
+    public List<Stat> Stats { get; set; } = new List<Stat>();
 }
 
 public class GameStatsResponse
 {
-    public List<object> Groups { get; set; }
-    public List<StatListCollection> StatListsCollection { get; set; }
+    public List<object> Groups { get; set; } = new List<object>();
+    public List<StatListCollection> StatListsCollection { get; set; } = new List<StatListCollection>();
 }
 
 public class AchievementRewards
@@ -377,7 +377,7 @@ public class AchievementRewards
 
     public string? type { get; set; }
 
-    public MediaAssets mediaAsset { get; set; }
+    public MediaAssets? mediaAsset { get; set; }
     public string? valueType { get; set; }
 
 }
@@ -416,7 +416,7 @@ public class AchievementRequirements
 
 public class AchievementProgression
 {
-    public List<AchievementRequirements> requirements { get; set; }
+    public List<AchievementRequirements> requirements { get; set; } = new List<AchievementRequirements>();
     public string? timeUnlocked { get; set; }
 
 }
@@ -445,7 +445,7 @@ public class AchievementEntryResponse
     public List<TitleAssociations> titleAssociations { get; set; } = new List<TitleAssociations>();
     public AchievementProgression progression { get; set; } = new AchievementProgression();
     public List<AchievementRewards> rewards { get; set; } = new List<AchievementRewards>();
-    public Rarity rarity { get; set; }
+    public Rarity? rarity { get; set; }
     public object? gamerscore { get; set; }
     public string? id { get; set; }
     public string? serviceConfigId { get; set; }
@@ -470,7 +470,7 @@ public class AchievementEntryResponse
     public string? productId { get; set; }
     public string? achievementType { get; set; }
     public string? participationType { get; set; }
-    public TimeWindow timeWindow { get; set; }
+    public TimeWindow? timeWindow { get; set; }
     public string? rewardsname { get; set; }
     public string? rewardsdescription { get; set; }
     public string? rewardsvalue { get; set; }
@@ -490,7 +490,8 @@ public class AchievementsResponse
     public List<AchievementEntryResponse> achievements { get; set; } = new List<AchievementEntryResponse>();
 }
 
-public class TimeWindow {
+public class TimeWindow
+{
     public string? startDate { get; set; }
     public string? endDate { get; set; }
 

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -390,13 +390,6 @@ public class Rarity
 
 }
 
-public class Gamerscore
-{
-    public string? currentGamerscore { get; set; }
-
-    public string? totalGamerscore { get; set; }
-
-}
 
 public class AchievementRequirements
 {
@@ -448,18 +441,20 @@ public class AchievementEntryResponse
     public Rarity? rarity { get; set; }
     public object? gamerscore { get; set; }
     public string? id { get; set; }
-    public string? serviceConfigId { get; set; }
+    public string serviceConfigId { get; set; } = StringConstants.ZeroUid;
     public string? name { get; set; }
     public string? titleAssociationsname { get; set; }
     public string? titleAssociationsid { get; set; }
-    public string? progressState { get; set; }
-    public string? progressionrequirementsid { get; set; }
-    public string? progressionrequirementscurrent { get; set; }
-    public string? progressionrequirementstarget { get; set; }
-    public string? progressionrequirementsoperationType { get; set; }
-    public string? progressionrequirementsvalueType { get; set; }
-    public string? progressionrequirementsruleParticipationType { get; set; }
-    public string? progressiontimeUnlocked { get; set; }
+    public string progressState { get; set; } = "Null";
+    //these are strings because im too lazy to handle them properly right now
+
+    public string progressionrequirementsid { get; set; } =  "AchievementResponse.achievements[i].progression.requirements[0].id";
+    public string progressionrequirementscurrent { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].current";
+    public string progressionrequirementstarget { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].target";
+    public string progressionrequirementsoperationType { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].operationType";
+    public string progressionrequirementsvalueType { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].valueType";
+    public string progressionrequirementsruleParticipationType { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].ruleParticipationType";
+    public string progressiontimeUnlocked { get; set; } = "0001-01-01T00:00:00.0000000Z";
     public string? mediaAssetsname { get; set; }
     public string? mediaAssetstype { get; set; }
     public string? mediaAssetsurl { get; set; }
@@ -471,11 +466,11 @@ public class AchievementEntryResponse
     public string? achievementType { get; set; }
     public string? participationType { get; set; }
     public TimeWindow? timeWindow { get; set; }
-    public string? rewardsname { get; set; }
-    public string? rewardsdescription { get; set; }
+    public string? rewardsname { get; set; } = "Null";
+    public string? rewardsdescription { get; set; } = "Null";
     public string? rewardsvalue { get; set; }
-    public string? rewardstype { get; set; }
-    public string? rewardsmediaAsset { get; set; }
+    public string? rewardstype { get; set; } = "Gamerscore";
+    public string? rewardsmediaAsset { get; set; } = "Null";
     public string? rewardsvalueType { get; set; }
     public string? estimatedTime { get; set; }
     public string? deeplink { get; set; }
@@ -492,51 +487,10 @@ public class AchievementsResponse
 
 public class TimeWindow
 {
-    public string? startDate { get; set; }
-    public string? endDate { get; set; }
+    public required string startDate { get; set; }
+    public required string endDate { get; set; }
 
 }
-public class DraffAchievement
-{
-    public string? id { get; set; }
-    public string? serviceConfigId { get; set; }
-    public string? name { get; set; }
-    public string? titleAssociationsname { get; set; }
-    public string? titleAssociationsid { get; set; }
-    public string? progressState { get; set; }
-    public string? progressionrequirementsid { get; set; }
-    public string? progressionrequirementscurrent { get; set; }
-    public string? progressionrequirementstarget { get; set; }
-    public string? progressionrequirementsoperationType { get; set; }
-    public string? progressionrequirementsvalueType { get; set; }
-    public string? progressionrequirementsruleParticipationType { get; set; }
-    public string? progressiontimeUnlocked { get; set; }
-    public string? mediaAssetsname { get; set; }
-    public string? mediaAssetstype { get; set; }
-    public string? mediaAssetsurl { get; set; }
-    public List<string> platforms { get; set; } = new List<string>();
-    public string? isSecret { get; set; }
-    public string? description { get; set; }
-    public string? lockedDescription { get; set; }
-    public string? productId { get; set; }
-    public string? achievementType { get; set; }
-    public string? participationType { get; set; }
-    public TimeWindow? timeWindow { get; set; }
-    public string? rewardsname { get; set; }
-    public string? rewardsdescription { get; set; }
-    public string? rewardsvalue { get; set; }
-    public string? rewardstype { get; set; }
-    public string? rewardsmediaAsset { get; set; }
-    public string? rewardsvalueType { get; set; }
-    public string? estimatedTime { get; set; }
-    public string? deeplink { get; set; }
-    public string? isRevoked { get; set; }
-    public string? raritycurrentCategory { get; set; }
-    public string? raritycurrentPercentage { get; set; }
-
-}
-
-
 
 public class Image
 {

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -346,7 +346,7 @@ public class AchievementEntryResponse
     public string productId { get; set; }
     public string achievementType { get; set; }
     public string participationType { get; set; }
-    public string timeWindow { get; set; }
+    public TimeWindow timeWindow { get; set; }
     public string rewardsname { get; set; }
     public string rewardsdescription { get; set; }
     public string rewardsvalue { get; set; }
@@ -366,7 +366,11 @@ public class AchievementsResponse
     public List<AchievementEntryResponse> achievements { get; set; }
 }
 
+public class TimeWindow {
+    public string startDate { get; set; }
+    public string endDate { get; set; }
 
+}
 public class DraffAchievement
 {
     public string id { get; set; }
@@ -392,7 +396,7 @@ public class DraffAchievement
     public string productId { get; set; }
     public string achievementType { get; set; }
     public string participationType { get; set; }
-    public string timeWindow { get; set; }
+    public TimeWindow timeWindow { get; set; }
     public string rewardsname { get; set; }
     public string rewardsdescription { get; set; }
     public string rewardsvalue { get; set; }

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -322,20 +322,20 @@ public class AchievementEntryResponse
     public AchievementProgression progression { get; set; }
     public List<AchievementRewards> rewards { get; set; }
     public Rarity rarity { get; set; }
-    public object gamerscore { get; set; }
-    public string id { get; set; }
-    public string serviceConfigId { get; set; }
-    public string name { get; set; }
-    public string titleAssociationsname { get; set; }
-    public string titleAssociationsid { get; set; }
-    public string progressState { get; set; }
-    public string progressionrequirementsid { get; set; }
-    public string progressionrequirementscurrent { get; set; }
-    public string progressionrequirementstarget { get; set; }
-    public string progressionrequirementsoperationType { get; set; }
-    public string progressionrequirementsvalueType { get; set; }
-    public string progressionrequirementsruleParticipationType { get; set; }
-    public string progressiontimeUnlocked { get; set; }
+    public object? gamerscore { get; set; }
+    public string? id { get; set; }
+    public string? serviceConfigId { get; set; }
+    public string? name { get; set; }
+    public string? titleAssociationsname { get; set; }
+    public string? titleAssociationsid { get; set; }
+    public string? progressState { get; set; }
+    public string? progressionrequirementsid { get; set; }
+    public string? progressionrequirementscurrent { get; set; }
+    public string? progressionrequirementstarget { get; set; }
+    public string? progressionrequirementsoperationType { get; set; }
+    public string? progressionrequirementsvalueType { get; set; }
+    public string? progressionrequirementsruleParticipationType { get; set; }
+    public string? progressiontimeUnlocked { get; set; }
     public string mediaAssetsname { get; set; }
     public string mediaAssetstype { get; set; }
     public string mediaAssetsurl { get; set; }
@@ -347,17 +347,17 @@ public class AchievementEntryResponse
     public string achievementType { get; set; }
     public string participationType { get; set; }
     public TimeWindow timeWindow { get; set; }
-    public string rewardsname { get; set; }
-    public string rewardsdescription { get; set; }
-    public string rewardsvalue { get; set; }
-    public string rewardstype { get; set; }
-    public string rewardsmediaAsset { get; set; }
-    public string rewardsvalueType { get; set; }
-    public string estimatedTime { get; set; }
-    public string deeplink { get; set; }
-    public string isRevoked { get; set; }
-    public string raritycurrentCategory { get; set; }
-    public string raritycurrentPercentage { get; set; }
+    public string? rewardsname { get; set; }
+    public string? rewardsdescription { get; set; }
+    public string? rewardsvalue { get; set; }
+    public string? rewardstype { get; set; }
+    public string? rewardsmediaAsset { get; set; }
+    public string? rewardsvalueType { get; set; }
+    public string? estimatedTime { get; set; }
+    public string? deeplink { get; set; }
+    public string? isRevoked { get; set; }
+    public string? raritycurrentCategory { get; set; }
+    public string? raritycurrentPercentage { get; set; }
 
 }
 

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -373,41 +373,41 @@ public class TimeWindow {
 }
 public class DraffAchievement
 {
-    public string id { get; set; }
-    public string serviceConfigId { get; set; }
-    public string name { get; set; }
-    public string titleAssociationsname { get; set; }
-    public string titleAssociationsid { get; set; }
-    public string progressState { get; set; }
-    public string progressionrequirementsid { get; set; }
-    public string progressionrequirementscurrent { get; set; }
-    public string progressionrequirementstarget { get; set; }
-    public string progressionrequirementsoperationType { get; set; }
-    public string progressionrequirementsvalueType { get; set; }
-    public string progressionrequirementsruleParticipationType { get; set; }
-    public string progressiontimeUnlocked { get; set; }
-    public string mediaAssetsname { get; set; }
-    public string mediaAssetstype { get; set; }
-    public string mediaAssetsurl { get; set; }
-    public List<string> platforms { get; set; }
-    public string isSecret { get; set; }
-    public string description { get; set; }
-    public string lockedDescription { get; set; }
-    public string productId { get; set; }
-    public string achievementType { get; set; }
-    public string participationType { get; set; }
-    public TimeWindow timeWindow { get; set; }
-    public string rewardsname { get; set; }
-    public string rewardsdescription { get; set; }
-    public string rewardsvalue { get; set; }
-    public string rewardstype { get; set; }
-    public string rewardsmediaAsset { get; set; }
-    public string rewardsvalueType { get; set; }
-    public string estimatedTime { get; set; }
-    public string deeplink { get; set; }
-    public string isRevoked { get; set; }
-    public string raritycurrentCategory { get; set; }
-    public string raritycurrentPercentage { get; set; }
+    public string? id { get; set; }
+    public string? serviceConfigId { get; set; }
+    public string? name { get; set; }
+    public string? titleAssociationsname { get; set; }
+    public string? titleAssociationsid { get; set; }
+    public string? progressState { get; set; }
+    public string? progressionrequirementsid { get; set; }
+    public string? progressionrequirementscurrent { get; set; }
+    public string? progressionrequirementstarget { get; set; }
+    public string? progressionrequirementsoperationType { get; set; }
+    public string? progressionrequirementsvalueType { get; set; }
+    public string? progressionrequirementsruleParticipationType { get; set; }
+    public string? progressiontimeUnlocked { get; set; }
+    public string? mediaAssetsname { get; set; }
+    public string? mediaAssetstype { get; set; }
+    public string? mediaAssetsurl { get; set; }
+    public List<string> platforms { get; set; } = new List<string>();
+    public string? isSecret { get; set; }
+    public string? description { get; set; }
+    public string? lockedDescription { get; set; }
+    public string? productId { get; set; }
+    public string? achievementType { get; set; }
+    public string? participationType { get; set; }
+    public TimeWindow? timeWindow { get; set; }
+    public string? rewardsname { get; set; }
+    public string? rewardsdescription { get; set; }
+    public string? rewardsvalue { get; set; }
+    public string? rewardstype { get; set; }
+    public string? rewardsmediaAsset { get; set; }
+    public string? rewardsvalueType { get; set; }
+    public string? estimatedTime { get; set; }
+    public string? deeplink { get; set; }
+    public string? isRevoked { get; set; }
+    public string? raritycurrentCategory { get; set; }
+    public string? raritycurrentPercentage { get; set; }
 
 }
 
@@ -415,37 +415,37 @@ public class DraffAchievement
 
 public class Image
 {
-    public string URI { get; set; }
+    public string? URI { get; set; }
     public int Height { get; set; }
     public int Width { get; set; }
-    public string Caption { get; set; }
+    public string? Caption { get; set; }
 }
 
 public class Product
 {
     public bool PCPlatformPreinstallable { get; set; }
-    public string ProductTitle { get; set; }
-    public string ProductDescription { get; set; }
-    public string ProductDescriptionShort { get; set; }
-    public string PackageFamilyName { get; set; }
-    public string ProductType { get; set; }
-    public object ChildPackageFamilyNames { get; set; }
-    public string XboxTitleId { get; set; }
-    public object ChildXboxTitleIds { get; set; }
+    public string? ProductTitle { get; set; }
+    public string? ProductDescription { get; set; }
+    public string? ProductDescriptionShort { get; set; }
+    public string? PackageFamilyName { get; set; }
+    public string? ProductType { get; set; }
+    public object? ChildPackageFamilyNames { get; set; }
+    public string? XboxTitleId { get; set; }
+    public object? ChildXboxTitleIds { get; set; }
     public int MinimumUserAge { get; set; }
     public List<object> Children { get; set; }
     public List<string> Categories { get; set; }
     public List<object> Attributes { get; set; }
-    public object HeroTrailer { get; set; }
+    public object? HeroTrailer { get; set; }
     public Image ImageBoxArt { get; set; }
     public Image ImageHero { get; set; }
     public object ImageTitledHero { get; set; }
     public Image ImagePoster { get; set; }
-    public object ImageTile { get; set; }
-    public object PCComingSoonDate { get; set; }
-    public object PCExitDate { get; set; }
-    public object UltimateComingSoonDate { get; set; }
-    public object UltimateExitDate { get; set; }
+    public object? ImageTile { get; set; }
+    public object? PCComingSoonDate { get; set; }
+    public object? PCExitDate { get; set; }
+    public object? UltimateComingSoonDate { get; set; }
+    public object? UltimateExitDate { get; set; }
     public bool IsEAPlay { get; set; }
     public List<object> XCloudSupportedInputs { get; set; }
     public object GameCatalogExtensionId { get; set; }
@@ -454,6 +454,6 @@ public class Product
 
 public class GamePassProducts
 {
-    public Dictionary<string, Product> Products { get; set; }
-    public List<object> InvalidIds { get; set; }
+    public Dictionary<string, Product> Products { get; set; } = new Dictionary<string, Product>();
+    public List<object> InvalidIds { get; set; } = new List<object>();
 }

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -5,50 +5,50 @@
 
 public class PersonResponse
 {
-    public string? Xuid { get; set; }
+    public string Xuid { get; set; }
     public bool IsFavorite { get; set; }
     public bool IsFollowingCaller { get; set; }
     public bool IsFollowedByCaller { get; set; }
     public bool IsIdentityShared { get; set; }
     public DateTime? AddedDateTimeUtc { get; set; }
-    public string? DisplayName { get; set; }
-    public string? RealName { get; set; }
-    public string? DisplayPicRaw { get; set; }
-    public string? ShowUserAsAvatar { get; set; }
-    public string? Gamertag { get; set; }
-    public string? GamerScore { get; set; }
-    public string? ModernGamertag { get; set; }
-    public string? ModernGamertagSuffix { get; set; }
-    public string? UniqueModernGamertag { get; set; }
-    public string? XboxOneRep { get; set; }
-    public string? PresenceState { get; set; }
-    public string? PresenceText { get; set; }
-    public object? PresenceDevices { get; set; }
+    public string DisplayName { get; set; }
+    public string RealName { get; set; }
+    public string DisplayPicRaw { get; set; }
+    public string ShowUserAsAvatar { get; set; }
+    public string Gamertag { get; set; }
+    public string GamerScore { get; set; }
+    public string ModernGamertag { get; set; }
+    public string ModernGamertagSuffix { get; set; }
+    public string UniqueModernGamertag { get; set; }
+    public string XboxOneRep { get; set; }
+    public string PresenceState { get; set; }
+    public string PresenceText { get; set; }
+    public object PresenceDevices { get; set; }
     public bool IsBroadcasting { get; set; }
     public bool IsCloaked { get; set; }
     public bool IsQuarantined { get; set; }
     public bool IsXbox360Gamerpic { get; set; }
     public DateTime? LastSeenDateTimeUtc { get; set; }
-    public object? Suggestion { get; set; }
-    public object? Recommendation { get; set; }
-    public object? Search { get; set; }
-    public object? TitleHistory { get; set; }
+    public object Suggestion { get; set; }
+    public object Recommendation { get; set; }
+    public object Search { get; set; }
+    public object TitleHistory { get; set; }
     public MultiplayerSummary MultiplayerSummary { get; set; }
-    public object? RecentPlayer { get; set; }
-    public object? Follower { get; set; }
+    public object RecentPlayer { get; set; }
+    public object Follower { get; set; }
     public PreferredColor PreferredColor { get; set; }
     public List<PresenceDetail> PresenceDetails { get; set; }
-    public object? TitlePresence { get; set; }
-    public object? TitleSummaries { get; set; }
-    public object? PresenceTitleIds { get; set; }
+    public object TitlePresence { get; set; }
+    public object TitleSummaries { get; set; }
+    public object PresenceTitleIds { get; set; }
     public Detail Detail { get; set; }
-    public object? CommunityManagerTitles { get; set; }
-    public object? SocialManager { get; set; }
-    public object? Broadcast { get; set; }
-    public object? Avatar { get; set; }
+    public object CommunityManagerTitles { get; set; }
+    public object SocialManager { get; set; }
+    public object Broadcast { get; set; }
+    public object Avatar { get; set; }
     public List<LinkedAccount> LinkedAccounts { get; set; }
-    public string? ColorTheme { get; set; }
-    public string? PreferredFlag { get; set; }
+    public string ColorTheme { get; set; }
+    public string PreferredFlag { get; set; }
     public List<object> PreferredPlatforms { get; set; }
 }
 
@@ -61,33 +61,33 @@ public class MultiplayerSummary
 
 public class PreferredColor
 {
-    public string? PrimaryColor { get; set; }
-    public string? SecondaryColor { get; set; }
-    public string? TertiaryColor { get; set; }
+    public string PrimaryColor { get; set; }
+    public string SecondaryColor { get; set; }
+    public string TertiaryColor { get; set; }
 }
 
 public class PresenceDetail
 {
     public bool IsBroadcasting { get; set; }
-    public string? Device { get; set; }
-    public object? DeviceSubType { get; set; }
-    public object? GameplayType { get; set; }
-    public string? PresenceText { get; set; }
-    public string? State { get; set; }
-    public string? TitleId { get; set; }
-    public object? TitleType { get; set; }
+    public string Device { get; set; }
+    public object DeviceSubType { get; set; }
+    public object GameplayType { get; set; }
+    public string PresenceText { get; set; }
+    public string State { get; set; }
+    public string TitleId { get; set; }
+    public object TitleType { get; set; }
     public bool IsPrimary { get; set; }
     public bool IsGame { get; set; }
-    public object? RichPresenceText { get; set; }
+    public object RichPresenceText { get; set; }
 }
 
 public class Detail
 {
-    public string? AccountTier { get; set; }
-    public string? Bio { get; set; }
+    public string AccountTier { get; set; }
+    public string Bio { get; set; }
     public bool IsVerified { get; set; }
-    public string? Location { get; set; }
-    public string? Tenure { get; set; }
+    public string Location { get; set; }
+    public string Tenure { get; set; }
     public List<string> Watermarks { get; set; } = new List<string>();
     public bool Blocked { get; set; }
     public bool Mute { get; set; }
@@ -98,46 +98,46 @@ public class Detail
 
 public class LinkedAccount
 {
-    public string? NetworkName { get; set; }
-    public string? DisplayName { get; set; }
+    public string NetworkName { get; set; }
+    public string DisplayName { get; set; }
     public bool ShowOnProfile { get; set; }
     public bool IsFamilyFriendly { get; set; }
-    public string? Deeplink { get; set; }
+    public string Deeplink { get; set; }
 }
 
 public class Profile
 {
     public List<PersonResponse> People { get; set; } = new List<PersonResponse>();
-    public object? RecommendationSummary { get; set; }
-    public object? FriendFinderState { get; set; }
-    public object? AccountLinkDetails { get; set; }
+    public object RecommendationSummary { get; set; }
+    public object FriendFinderState { get; set; }
+    public object AccountLinkDetails { get; set; }
 }
 
 
 public class XboxTitle
 {
-    public string? TitleId { get; set; }
-    public string? Pfn { get; set; }
-    public string? BingId { get; set; }
-    public string? WindowsPhoneProductId { get; set; }
-    public string? Name { get; set; }
-    public string? Type { get; set; }
+    public string TitleId { get; set; }
+    public string Pfn { get; set; }
+    public string BingId { get; set; }
+    public string WindowsPhoneProductId { get; set; }
+    public string Name { get; set; }
+    public string Type { get; set; }
     public List<string> Devices { get; set; }
-    public string? DisplayImage { get; set; }
-    public string? MediaItemType { get; set; }
-    public string? ModernTitleId { get; set; }
+    public string DisplayImage { get; set; }
+    public string MediaItemType { get; set; }
+    public string ModernTitleId { get; set; }
     public bool IsBundle { get; set; }
     public BasicAchievementDetails Achievement { get; set; }
     public Stats Stats { get; set; }
     public GamePass GamePass { get; set; }
-    public object? Images { get; set; }
-    public object? TitleHistory { get; set; }
-    public object? TitleRecord { get; set; }
-    public object? Detail { get; set; }
-    public object? FriendsWhoPlayed { get; set; }
-    public object? AlternateTitleIds { get; set; }
-    public object? ContentBoards { get; set; }
-    public string? XboxLiveTier { get; set; }
+    public object Images { get; set; }
+    public object TitleHistory { get; set; }
+    public object TitleRecord { get; set; }
+    public object Detail { get; set; }
+    public object FriendsWhoPlayed { get; set; }
+    public object AlternateTitleIds { get; set; }
+    public object ContentBoards { get; set; }
+    public string XboxLiveTier { get; set; }
 }
 
 public class BasicAchievementDetails
@@ -162,20 +162,20 @@ public class GamePass
 
 public class GameTitle
 {
-    public string? Xuid { get; set; }
+    public string Xuid { get; set; }
     public List<XboxTitle> Titles { get; set; }
 }
 
 public class GamepassData
 {
-    public string? GamepassMembership { get; set; }
+    public string GamepassMembership { get; set; }
 }
 
 public class Gamepass
 {
     // This json response is actually massive, but we don't care
     // TOOD: maybe we want to look at points/stuff later
-    public string? GamepassMembership { get; set; }
+    public string GamepassMembership { get; set; }
     public GamepassData Data { get; set; }
 }
 
@@ -188,49 +188,49 @@ public class TitleHistory
 
 public class Title
 {
-    public string? TitleId { get; set; }
-    public string? Pfn { get; set; }
-    public string? BingId { get; set; }
-    public string? ServiceConfigId { get; set; }
-    public string? WindowsPhoneProductId { get; set; }
-    public string? Name { get; set; }
-    public string? Type { get; set; }
+    public string TitleId { get; set; }
+    public string Pfn { get; set; }
+    public string BingId { get; set; }
+    public string ServiceConfigId { get; set; }
+    public string WindowsPhoneProductId { get; set; }
+    public string Name { get; set; }
+    public string Type { get; set; }
     public List<string> Devices { get; set; }
-    public string? DisplayImage { get; set; }
-    public string? MediaItemType { get; set; }
-    public string? ModernTitleId { get; set; }
+    public string DisplayImage { get; set; }
+    public string MediaItemType { get; set; }
+    public string ModernTitleId { get; set; }
     public bool IsBundle { get; set; }
     public BasicAchievementDetails Achievement { get; set; }
-    public object? Stats { get; set; }
-    public object? GamePass { get; set; }
-    public object? Images { get; set; }
+    public object Stats { get; set; }
+    public object GamePass { get; set; }
+    public object Images { get; set; }
     public TitleHistory TitleHistory { get; set; }
-    public object? TitleRecord { get; set; }
-    public object? Detail { get; set; }
-    public object? FriendsWhoPlayed { get; set; }
-    public object? AlternateTitleIds { get; set; }
-    public object? ContentBoards { get; set; }
-    public string? XboxLiveTier { get; set; }
+    public object TitleRecord { get; set; }
+    public object Detail { get; set; }
+    public object FriendsWhoPlayed { get; set; }
+    public object AlternateTitleIds { get; set; }
+    public object ContentBoards { get; set; }
+    public string XboxLiveTier { get; set; }
 }
 
 public class TitlesList
 {
-    public string? Xuid { get; set; }
+    public string Xuid { get; set; }
     public List<Title> Titles { get; set; }
 }
 
 public class ProfileSettings
 {
-    public string? Id { get; set; }
-    public string? Value { get; set; }
+    public string Id { get; set; }
+    public string Value { get; set; }
 }
 
 public class ProfileUser
 {
-    public string? Id { get; set; }
-    public string? HostId { get; set; }
+    public string Id { get; set; }
+    public string HostId { get; set; }
     public List<ProfileSettings> Settings { get; set; }
-    public string? IsSponsoredUser { get; set; }
+    public string IsSponsoredUser { get; set; }
 }
 
 public class BasicProfile
@@ -242,19 +242,19 @@ public class BasicProfile
 public class Stat
 {
     public Dictionary<string, object> GroupProperties { get; set; }
-    public string? Xuid { get; set; }
-    public string? Scid { get; set; }
-    public string? TitleId { get; set; }
-    public string? Name { get; set; }
-    public string? Type { get; set; }
-    public string? Value { get; set; }
+    public string Xuid { get; set; }
+    public string Scid { get; set; }
+    public string TitleId { get; set; }
+    public string Name { get; set; }
+    public string Type { get; set; }
+    public string Value { get; set; }
     public Dictionary<string, object> Properties { get; set; }
 }
 
 public class StatListCollection
 {
-    public string? ArrangeByField { get; set; }
-    public string? ArrangeByFieldId { get; set; }
+    public string ArrangeByField { get; set; }
+    public string ArrangeByFieldId { get; set; }
     public List<Stat> Stats { get; set; }
 }
 
@@ -266,61 +266,61 @@ public class GameStatsResponse
 
 public class AchievementRewards
 {
-    public string? name { get; set; }
-    public string? description { get; set; }
-    public string? value { get; set; }
-    public string? type { get; set; }
+    public string name { get; set; }
+    public string description { get; set; }
+    public string value { get; set; }
+    public string type { get; set; }
     public MediaAssets mediaAsset { get; set; }
-    public string? valueType { get; set; }
+    public string valueType { get; set; }
 }
 
 public class Rarity
 {
-    public string? currentCategory { get; set; }
-    public string? currentPercentage { get; set; }
+    public string currentCategory { get; set; }
+    public string currentPercentage { get; set; }
 }
 
 public class Gamerscore
 {
-    public string? currentGamerscore { get; set; }
-    public string? totalGamerscore { get; set; }
+    public string currentGamerscore { get; set; }
+    public string totalGamerscore { get; set; }
 }
 
 public class AchievementRequirements
 {
-    public string? id { get; set; }
-    public string? current { get; set; }
-    public string? target { get; set; }
-    public string? operationType { get; set; }
-    public string? valueType { get; set; }
-    public string? ruleParticipationType { get; set; }
+    public string id { get; set; }
+    public string current { get; set; }
+    public string target { get; set; }
+    public string operationType { get; set; }
+    public string valueType { get; set; }
+    public string ruleParticipationType { get; set; }
 }
 
 public class AchievementProgression
 {
     public List<AchievementRequirements> requirements { get; set; }
-    public string? timeUnlocked { get; set; }
+    public string timeUnlocked { get; set; }
 }
 
 public class TitleAssociations
 {
-    public string? name { get; set; }
-    public string? id { get; set; }
+    public string name { get; set; }
+    public string id { get; set; }
 }
 
 public class MediaAssets
 {
-    public string? name { get; set; }
-    public string? type { get; set; }
-    public string? url { get; set; }
+    public string name { get; set; }
+    public string type { get; set; }
+    public string url { get; set; }
 }
 
 public class AchievementEntryResponse
 {
-    public List<MediaAssets> mediaAssets { get; set; }
-    public List<TitleAssociations> titleAssociations { get; set; }
-    public AchievementProgression progression { get; set; }
-    public List<AchievementRewards> rewards { get; set; }
+    public List<MediaAssets> mediaAssets { get; set; } = new List<MediaAssets>();
+    public List<TitleAssociations> titleAssociations { get; set; } = new List<TitleAssociations>();
+    public AchievementProgression progression { get; set; } = new AchievementProgression();
+    public List<AchievementRewards> rewards { get; set; } = new List<AchievementRewards>();
     public Rarity rarity { get; set; }
     public object? gamerscore { get; set; }
     public string? id { get; set; }
@@ -339,7 +339,7 @@ public class AchievementEntryResponse
     public string? mediaAssetsname { get; set; }
     public string? mediaAssetstype { get; set; }
     public string? mediaAssetsurl { get; set; }
-    public List<string> platforms { get; set; }
+    public List<string> platforms { get; set; } = new List<string>();
     public string? isSecret { get; set; }
     public string? description { get; set; }
     public string? lockedDescription { get; set; }
@@ -363,7 +363,7 @@ public class AchievementEntryResponse
 
 public class AchievementsResponse
 {
-    public List<AchievementEntryResponse> achievements { get; set; }
+    public List<AchievementEntryResponse> achievements { get; set; } = new List<AchievementEntryResponse>();
 }
 
 public class TimeWindow {
@@ -433,21 +433,21 @@ public class Product
     public string? XboxTitleId { get; set; }
     public object? ChildXboxTitleIds { get; set; }
     public int MinimumUserAge { get; set; }
-    public List<object> Children { get; set; }
-    public List<string> Categories { get; set; }
-    public List<object> Attributes { get; set; }
+    public List<object> Children { get; set; } = new List<object>();
+    public List<string> Categories { get; set; } = new List<string>();
+    public List<object> Attributes { get; set; } = new List<object>();
     public object? HeroTrailer { get; set; }
-    public Image ImageBoxArt { get; set; }
-    public Image ImageHero { get; set; }
+    public Image? ImageBoxArt { get; set; }
+    public Image? ImageHero { get; set; }
     public object? ImageTitledHero { get; set; }
-    public Image ImagePoster { get; set; }
+    public Image? ImagePoster { get; set; }
     public object? ImageTile { get; set; }
     public object? PCComingSoonDate { get; set; }
     public object? PCExitDate { get; set; }
     public object? UltimateComingSoonDate { get; set; }
     public object? UltimateExitDate { get; set; }
     public bool IsEAPlay { get; set; }
-    public List<object> XCloudSupportedInputs { get; set; }
+    public List<object> XCloudSupportedInputs { get; set; } = new List<object>();
     public object? GameCatalogExtensionId { get; set; }
     public string? StoreId { get; set; }
 }

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -174,7 +174,7 @@ public class XboxTitle
 
     public string? WindowsPhoneProductId { get; set; }
 
-    public string? Name { get; set; }
+    public required string Name { get; set; }
 
     public string? Type { get; set; }
 
@@ -377,7 +377,7 @@ public class AchievementRewards
 
     public string? type { get; set; }
 
-    public MediaAssets? mediaAsset { get; set; }
+    public MediaAsset? mediaAsset { get; set; }
     public string? valueType { get; set; }
 
 }
@@ -414,7 +414,7 @@ public class AchievementProgression
 
 }
 
-public class TitleAssociations
+public class TitleAssociation
 {
     public string? name { get; set; }
 
@@ -422,7 +422,7 @@ public class TitleAssociations
 
 }
 
-public class MediaAssets
+public class MediaAsset
 {
     public string? name { get; set; }
 
@@ -432,57 +432,57 @@ public class MediaAssets
 
 }
 
-public class AchievementEntryResponse
+
+
+public class OneCoreAchievementResponse // Xbox One Achievements
 {
-    public List<MediaAssets> mediaAssets { get; set; } = new List<MediaAssets>();
-    public List<TitleAssociations> titleAssociations { get; set; } = new List<TitleAssociations>();
-    public AchievementProgression progression { get; set; } = new AchievementProgression();
-    public List<AchievementRewards> rewards { get; set; } = new List<AchievementRewards>();
     public Rarity? rarity { get; set; }
     public object? gamerscore { get; set; }
-    public string? id { get; set; }
+    public required string id { get; set; }
     public string serviceConfigId { get; set; } = StringConstants.ZeroUid;
-    public string? name { get; set; }
-    public string? titleAssociationsname { get; set; }
-    public string? titleAssociationsid { get; set; }
+    public required string name { get; set; }
+    public List<TitleAssociation> titleAssociations { get; set; } = new List<TitleAssociation>();
     public string progressState { get; set; } = "Null";
-    //these are strings because im too lazy to handle them properly right now
-
-    public string progressionrequirementsid { get; set; } =  "AchievementResponse.achievements[i].progression.requirements[0].id";
-    public string progressionrequirementscurrent { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].current";
-    public string progressionrequirementstarget { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].target";
-    public string progressionrequirementsoperationType { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].operationType";
-    public string progressionrequirementsvalueType { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].valueType";
-    public string progressionrequirementsruleParticipationType { get; set; } = "AchievementResponse.achievements[i].progression.requirements[0].ruleParticipationType";
-    public string progressiontimeUnlocked { get; set; } = "0001-01-01T00:00:00.0000000Z";
-    public string? mediaAssetsname { get; set; }
-    public string? mediaAssetstype { get; set; }
-    public string? mediaAssetsurl { get; set; }
+    public AchievementProgression? progression { get; set; }
+    public List<MediaAsset> mediaAssets { get; set; } = new List<MediaAsset>();
     public List<string> platforms { get; set; } = new List<string>();
-    public string? isSecret { get; set; }
+    public bool isSecret { get; set; }
     public string? description { get; set; }
     public string? lockedDescription { get; set; }
     public string? productId { get; set; }
     public string? achievementType { get; set; }
     public string? participationType { get; set; }
     public TimeWindow? timeWindow { get; set; }
-    public string? rewardsname { get; set; } = "Null";
-    public string? rewardsdescription { get; set; } = "Null";
-    public string? rewardsvalue { get; set; }
-    public string? rewardstype { get; set; } = "Gamerscore";
-    public string? rewardsmediaAsset { get; set; } = "Null";
-    public string? rewardsvalueType { get; set; }
+    public List<AchievementRewards> rewards { get; set; } = new List<AchievementRewards>();
     public string? estimatedTime { get; set; }
     public string? deeplink { get; set; }
     public string? isRevoked { get; set; }
     public string? raritycurrentCategory { get; set; }
     public string? raritycurrentPercentage { get; set; }
+}
 
+public class Xbox360AchievementEntry
+{
+    public int id {get; set;}
+    public int titleId {get; set;}
+    public string name {get; set;}
+    public int gamerscore {get; set;}
+    public string description {get; set;}
+    public string lockedDescription {get; set;}
+    public string timeUnlocked {get; set;}
+    public bool isSecret {get; set;}
+    public Rarity? rarity {get; set;}
+
+}
+
+public class Xbox360AchievementResponse
+{
+    public List<Xbox360AchievementEntry> achievements {get;set; } = new List<Xbox360AchievementEntry>();
 }
 
 public class AchievementsResponse
 {
-    public List<AchievementEntryResponse> achievements { get; set; } = new List<AchievementEntryResponse>();
+    public List<OneCoreAchievementResponse> achievements { get; set; } = new List<OneCoreAchievementResponse>();
 }
 
 public class TimeWindow

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -410,3 +410,50 @@ public class DraffAchievement
     public string raritycurrentPercentage { get; set; }
 
 }
+
+
+
+public class Image
+{
+    public string URI { get; set; }
+    public int Height { get; set; }
+    public int Width { get; set; }
+    public string Caption { get; set; }
+}
+
+public class Product
+{
+    public bool PCPlatformPreinstallable { get; set; }
+    public string ProductTitle { get; set; }
+    public string ProductDescription { get; set; }
+    public string ProductDescriptionShort { get; set; }
+    public string PackageFamilyName { get; set; }
+    public string ProductType { get; set; }
+    public object ChildPackageFamilyNames { get; set; }
+    public string XboxTitleId { get; set; }
+    public object ChildXboxTitleIds { get; set; }
+    public int MinimumUserAge { get; set; }
+    public List<object> Children { get; set; }
+    public List<string> Categories { get; set; }
+    public List<object> Attributes { get; set; }
+    public object HeroTrailer { get; set; }
+    public Image ImageBoxArt { get; set; }
+    public Image ImageHero { get; set; }
+    public object ImageTitledHero { get; set; }
+    public Image ImagePoster { get; set; }
+    public object ImageTile { get; set; }
+    public object PCComingSoonDate { get; set; }
+    public object PCExitDate { get; set; }
+    public object UltimateComingSoonDate { get; set; }
+    public object UltimateExitDate { get; set; }
+    public bool IsEAPlay { get; set; }
+    public List<object> XCloudSupportedInputs { get; set; }
+    public object GameCatalogExtensionId { get; set; }
+    public string StoreId { get; set; }
+}
+
+public class GamePassProducts
+{
+    public Dictionary<string, Product> Products { get; set; }
+    public List<object> InvalidIds { get; set; }
+}

--- a/XAU/Models/XboxApiResponse.cs
+++ b/XAU/Models/XboxApiResponse.cs
@@ -5,50 +5,50 @@
 
 public class PersonResponse
 {
-    public string Xuid { get; set; }
+    public string? Xuid { get; set; }
     public bool IsFavorite { get; set; }
     public bool IsFollowingCaller { get; set; }
     public bool IsFollowedByCaller { get; set; }
     public bool IsIdentityShared { get; set; }
     public DateTime? AddedDateTimeUtc { get; set; }
-    public string DisplayName { get; set; }
-    public string RealName { get; set; }
-    public string DisplayPicRaw { get; set; }
-    public string ShowUserAsAvatar { get; set; }
-    public string Gamertag { get; set; }
-    public string GamerScore { get; set; }
-    public string ModernGamertag { get; set; }
-    public string ModernGamertagSuffix { get; set; }
-    public string UniqueModernGamertag { get; set; }
-    public string XboxOneRep { get; set; }
-    public string PresenceState { get; set; }
-    public string PresenceText { get; set; }
-    public object PresenceDevices { get; set; }
+    public string? DisplayName { get; set; }
+    public string? RealName { get; set; }
+    public string? DisplayPicRaw { get; set; }
+    public string? ShowUserAsAvatar { get; set; }
+    public string? Gamertag { get; set; }
+    public string? GamerScore { get; set; }
+    public string? ModernGamertag { get; set; }
+    public string? ModernGamertagSuffix { get; set; }
+    public string? UniqueModernGamertag { get; set; }
+    public string? XboxOneRep { get; set; }
+    public string? PresenceState { get; set; }
+    public string? PresenceText { get; set; }
+    public object? PresenceDevices { get; set; }
     public bool IsBroadcasting { get; set; }
     public bool IsCloaked { get; set; }
     public bool IsQuarantined { get; set; }
     public bool IsXbox360Gamerpic { get; set; }
     public DateTime? LastSeenDateTimeUtc { get; set; }
-    public object Suggestion { get; set; }
-    public object Recommendation { get; set; }
-    public object Search { get; set; }
-    public object TitleHistory { get; set; }
+    public object? Suggestion { get; set; }
+    public object? Recommendation { get; set; }
+    public object? Search { get; set; }
+    public object? TitleHistory { get; set; }
     public MultiplayerSummary MultiplayerSummary { get; set; }
-    public object RecentPlayer { get; set; }
-    public object Follower { get; set; }
+    public object? RecentPlayer { get; set; }
+    public object? Follower { get; set; }
     public PreferredColor PreferredColor { get; set; }
     public List<PresenceDetail> PresenceDetails { get; set; }
-    public object TitlePresence { get; set; }
-    public object TitleSummaries { get; set; }
-    public object PresenceTitleIds { get; set; }
+    public object? TitlePresence { get; set; }
+    public object? TitleSummaries { get; set; }
+    public object? PresenceTitleIds { get; set; }
     public Detail Detail { get; set; }
-    public object CommunityManagerTitles { get; set; }
-    public object SocialManager { get; set; }
-    public object Broadcast { get; set; }
-    public object Avatar { get; set; }
+    public object? CommunityManagerTitles { get; set; }
+    public object? SocialManager { get; set; }
+    public object? Broadcast { get; set; }
+    public object? Avatar { get; set; }
     public List<LinkedAccount> LinkedAccounts { get; set; }
-    public string ColorTheme { get; set; }
-    public string PreferredFlag { get; set; }
+    public string? ColorTheme { get; set; }
+    public string? PreferredFlag { get; set; }
     public List<object> PreferredPlatforms { get; set; }
 }
 
@@ -61,33 +61,33 @@ public class MultiplayerSummary
 
 public class PreferredColor
 {
-    public string PrimaryColor { get; set; }
-    public string SecondaryColor { get; set; }
-    public string TertiaryColor { get; set; }
+    public string? PrimaryColor { get; set; }
+    public string? SecondaryColor { get; set; }
+    public string? TertiaryColor { get; set; }
 }
 
 public class PresenceDetail
 {
     public bool IsBroadcasting { get; set; }
-    public string Device { get; set; }
-    public object DeviceSubType { get; set; }
-    public object GameplayType { get; set; }
-    public string PresenceText { get; set; }
-    public string State { get; set; }
-    public string TitleId { get; set; }
-    public object TitleType { get; set; }
+    public string? Device { get; set; }
+    public object? DeviceSubType { get; set; }
+    public object? GameplayType { get; set; }
+    public string? PresenceText { get; set; }
+    public string? State { get; set; }
+    public string? TitleId { get; set; }
+    public object? TitleType { get; set; }
     public bool IsPrimary { get; set; }
     public bool IsGame { get; set; }
-    public object RichPresenceText { get; set; }
+    public object? RichPresenceText { get; set; }
 }
 
 public class Detail
 {
-    public string AccountTier { get; set; }
-    public string Bio { get; set; }
+    public string? AccountTier { get; set; }
+    public string? Bio { get; set; }
     public bool IsVerified { get; set; }
-    public string Location { get; set; }
-    public string Tenure { get; set; }
+    public string? Location { get; set; }
+    public string? Tenure { get; set; }
     public List<string> Watermarks { get; set; } = new List<string>();
     public bool Blocked { get; set; }
     public bool Mute { get; set; }
@@ -98,46 +98,46 @@ public class Detail
 
 public class LinkedAccount
 {
-    public string NetworkName { get; set; }
-    public string DisplayName { get; set; }
+    public string? NetworkName { get; set; }
+    public string? DisplayName { get; set; }
     public bool ShowOnProfile { get; set; }
     public bool IsFamilyFriendly { get; set; }
-    public string Deeplink { get; set; }
+    public string? Deeplink { get; set; }
 }
 
 public class Profile
 {
     public List<PersonResponse> People { get; set; } = new List<PersonResponse>();
-    public object RecommendationSummary { get; set; }
-    public object FriendFinderState { get; set; }
-    public object AccountLinkDetails { get; set; }
+    public object? RecommendationSummary { get; set; }
+    public object? FriendFinderState { get; set; }
+    public object? AccountLinkDetails { get; set; }
 }
 
 
 public class XboxTitle
 {
-    public string TitleId { get; set; }
-    public string Pfn { get; set; }
-    public string BingId { get; set; }
-    public string WindowsPhoneProductId { get; set; }
-    public string Name { get; set; }
-    public string Type { get; set; }
+    public string? TitleId { get; set; }
+    public string? Pfn { get; set; }
+    public string? BingId { get; set; }
+    public string? WindowsPhoneProductId { get; set; }
+    public string? Name { get; set; }
+    public string? Type { get; set; }
     public List<string> Devices { get; set; }
-    public string DisplayImage { get; set; }
-    public string MediaItemType { get; set; }
-    public string ModernTitleId { get; set; }
+    public string? DisplayImage { get; set; }
+    public string? MediaItemType { get; set; }
+    public string? ModernTitleId { get; set; }
     public bool IsBundle { get; set; }
     public BasicAchievementDetails Achievement { get; set; }
     public Stats Stats { get; set; }
     public GamePass GamePass { get; set; }
-    public object Images { get; set; }
-    public object TitleHistory { get; set; }
-    public object TitleRecord { get; set; }
-    public object Detail { get; set; }
-    public object FriendsWhoPlayed { get; set; }
-    public object AlternateTitleIds { get; set; }
-    public object ContentBoards { get; set; }
-    public string XboxLiveTier { get; set; }
+    public object? Images { get; set; }
+    public object? TitleHistory { get; set; }
+    public object? TitleRecord { get; set; }
+    public object? Detail { get; set; }
+    public object? FriendsWhoPlayed { get; set; }
+    public object? AlternateTitleIds { get; set; }
+    public object? ContentBoards { get; set; }
+    public string? XboxLiveTier { get; set; }
 }
 
 public class BasicAchievementDetails
@@ -162,20 +162,20 @@ public class GamePass
 
 public class GameTitle
 {
-    public string Xuid { get; set; }
+    public string? Xuid { get; set; }
     public List<XboxTitle> Titles { get; set; }
 }
 
 public class GamepassData
 {
-    public string GamepassMembership { get; set; }
+    public string? GamepassMembership { get; set; }
 }
 
 public class Gamepass
 {
     // This json response is actually massive, but we don't care
     // TOOD: maybe we want to look at points/stuff later
-    public string GamepassMembership { get; set; }
+    public string? GamepassMembership { get; set; }
     public GamepassData Data { get; set; }
 }
 
@@ -188,49 +188,49 @@ public class TitleHistory
 
 public class Title
 {
-    public string TitleId { get; set; }
-    public string Pfn { get; set; }
-    public string BingId { get; set; }
-    public string ServiceConfigId { get; set; }
-    public string WindowsPhoneProductId { get; set; }
-    public string Name { get; set; }
-    public string Type { get; set; }
+    public string? TitleId { get; set; }
+    public string? Pfn { get; set; }
+    public string? BingId { get; set; }
+    public string? ServiceConfigId { get; set; }
+    public string? WindowsPhoneProductId { get; set; }
+    public string? Name { get; set; }
+    public string? Type { get; set; }
     public List<string> Devices { get; set; }
-    public string DisplayImage { get; set; }
-    public string MediaItemType { get; set; }
-    public string ModernTitleId { get; set; }
+    public string? DisplayImage { get; set; }
+    public string? MediaItemType { get; set; }
+    public string? ModernTitleId { get; set; }
     public bool IsBundle { get; set; }
     public BasicAchievementDetails Achievement { get; set; }
-    public object Stats { get; set; }
-    public object GamePass { get; set; }
-    public object Images { get; set; }
+    public object? Stats { get; set; }
+    public object? GamePass { get; set; }
+    public object? Images { get; set; }
     public TitleHistory TitleHistory { get; set; }
-    public object TitleRecord { get; set; }
-    public object Detail { get; set; }
-    public object FriendsWhoPlayed { get; set; }
-    public object AlternateTitleIds { get; set; }
-    public object ContentBoards { get; set; }
-    public string XboxLiveTier { get; set; }
+    public object? TitleRecord { get; set; }
+    public object? Detail { get; set; }
+    public object? FriendsWhoPlayed { get; set; }
+    public object? AlternateTitleIds { get; set; }
+    public object? ContentBoards { get; set; }
+    public string? XboxLiveTier { get; set; }
 }
 
 public class TitlesList
 {
-    public string Xuid { get; set; }
+    public string? Xuid { get; set; }
     public List<Title> Titles { get; set; }
 }
 
 public class ProfileSettings
 {
-    public string Id { get; set; }
-    public string Value { get; set; }
+    public string? Id { get; set; }
+    public string? Value { get; set; }
 }
 
 public class ProfileUser
 {
-    public string Id { get; set; }
-    public string HostId { get; set; }
+    public string? Id { get; set; }
+    public string? HostId { get; set; }
     public List<ProfileSettings> Settings { get; set; }
-    public string IsSponsoredUser { get; set; }
+    public string? IsSponsoredUser { get; set; }
 }
 
 public class BasicProfile
@@ -242,19 +242,19 @@ public class BasicProfile
 public class Stat
 {
     public Dictionary<string, object> GroupProperties { get; set; }
-    public string Xuid { get; set; }
-    public string Scid { get; set; }
-    public string TitleId { get; set; }
-    public string Name { get; set; }
-    public string Type { get; set; }
-    public string Value { get; set; }
+    public string? Xuid { get; set; }
+    public string? Scid { get; set; }
+    public string? TitleId { get; set; }
+    public string? Name { get; set; }
+    public string? Type { get; set; }
+    public string? Value { get; set; }
     public Dictionary<string, object> Properties { get; set; }
 }
 
 public class StatListCollection
 {
-    public string ArrangeByField { get; set; }
-    public string ArrangeByFieldId { get; set; }
+    public string? ArrangeByField { get; set; }
+    public string? ArrangeByFieldId { get; set; }
     public List<Stat> Stats { get; set; }
 }
 
@@ -266,53 +266,53 @@ public class GameStatsResponse
 
 public class AchievementRewards
 {
-    public string name { get; set; }
-    public string description { get; set; }
-    public string value { get; set; }
-    public string type { get; set; }
+    public string? name { get; set; }
+    public string? description { get; set; }
+    public string? value { get; set; }
+    public string? type { get; set; }
     public MediaAssets mediaAsset { get; set; }
-    public string valueType { get; set; }
+    public string? valueType { get; set; }
 }
 
 public class Rarity
 {
-    public string currentCategory { get; set; }
-    public string currentPercentage { get; set; }
+    public string? currentCategory { get; set; }
+    public string? currentPercentage { get; set; }
 }
 
 public class Gamerscore
 {
-    public string currentGamerscore { get; set; }
-    public string totalGamerscore { get; set; }
+    public string? currentGamerscore { get; set; }
+    public string? totalGamerscore { get; set; }
 }
 
 public class AchievementRequirements
 {
-    public string id { get; set; }
-    public string current { get; set; }
-    public string target { get; set; }
-    public string operationType { get; set; }
-    public string valueType { get; set; }
-    public string ruleParticipationType { get; set; }
+    public string? id { get; set; }
+    public string? current { get; set; }
+    public string? target { get; set; }
+    public string? operationType { get; set; }
+    public string? valueType { get; set; }
+    public string? ruleParticipationType { get; set; }
 }
 
 public class AchievementProgression
 {
     public List<AchievementRequirements> requirements { get; set; }
-    public string timeUnlocked { get; set; }
+    public string? timeUnlocked { get; set; }
 }
 
 public class TitleAssociations
 {
-    public string name { get; set; }
-    public string id { get; set; }
+    public string? name { get; set; }
+    public string? id { get; set; }
 }
 
 public class MediaAssets
 {
-    public string name { get; set; }
-    public string type { get; set; }
-    public string url { get; set; }
+    public string? name { get; set; }
+    public string? type { get; set; }
+    public string? url { get; set; }
 }
 
 public class AchievementEntryResponse
@@ -336,16 +336,16 @@ public class AchievementEntryResponse
     public string? progressionrequirementsvalueType { get; set; }
     public string? progressionrequirementsruleParticipationType { get; set; }
     public string? progressiontimeUnlocked { get; set; }
-    public string mediaAssetsname { get; set; }
-    public string mediaAssetstype { get; set; }
-    public string mediaAssetsurl { get; set; }
+    public string? mediaAssetsname { get; set; }
+    public string? mediaAssetstype { get; set; }
+    public string? mediaAssetsurl { get; set; }
     public List<string> platforms { get; set; }
-    public string isSecret { get; set; }
-    public string description { get; set; }
-    public string lockedDescription { get; set; }
-    public string productId { get; set; }
-    public string achievementType { get; set; }
-    public string participationType { get; set; }
+    public string? isSecret { get; set; }
+    public string? description { get; set; }
+    public string? lockedDescription { get; set; }
+    public string? productId { get; set; }
+    public string? achievementType { get; set; }
+    public string? participationType { get; set; }
     public TimeWindow timeWindow { get; set; }
     public string? rewardsname { get; set; }
     public string? rewardsdescription { get; set; }
@@ -367,8 +367,8 @@ public class AchievementsResponse
 }
 
 public class TimeWindow {
-    public string startDate { get; set; }
-    public string endDate { get; set; }
+    public string? startDate { get; set; }
+    public string? endDate { get; set; }
 
 }
 public class DraffAchievement
@@ -439,7 +439,7 @@ public class Product
     public object? HeroTrailer { get; set; }
     public Image ImageBoxArt { get; set; }
     public Image ImageHero { get; set; }
-    public object ImageTitledHero { get; set; }
+    public object? ImageTitledHero { get; set; }
     public Image ImagePoster { get; set; }
     public object? ImageTile { get; set; }
     public object? PCComingSoonDate { get; set; }
@@ -448,8 +448,8 @@ public class Product
     public object? UltimateExitDate { get; set; }
     public bool IsEAPlay { get; set; }
     public List<object> XCloudSupportedInputs { get; set; }
-    public object GameCatalogExtensionId { get; set; }
-    public string StoreId { get; set; }
+    public object? GameCatalogExtensionId { get; set; }
+    public string? StoreId { get; set; }
 }
 
 public class GamePassProducts

--- a/XAU/Networking/GithubRestApi.cs
+++ b/XAU/Networking/GithubRestApi.cs
@@ -9,7 +9,6 @@ public class GithubRestApi
     // User specifics
     public GithubRestApi()
     {
-        // This is a placeholder for the Xbox REST API
         var handler = new HttpClientHandler()
         {
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate

--- a/XAU/Networking/GithubRestApi.cs
+++ b/XAU/Networking/GithubRestApi.cs
@@ -27,15 +27,13 @@ public class GithubRestApi
             "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8");
     }
 
-    public async Task<dynamic> GetDevToolVersionAsync()
+    public async Task<VersionResponse?> GetDevToolVersionAsync()
     {
         SetDefaultHeaders();
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Host, Hosts.GitHubRaw);
         var responseString =
             await _httpClient.GetStringAsync("https://raw.githubusercontent.com/Fumo-Unlockers/Xbox-Achievement-Unlocker/Pre-Release/info.json");
-
-        var jsonResponse = (dynamic)JObject.Parse(responseString);
-        return jsonResponse;
+        return JsonConvert.DeserializeObject<VersionResponse>(responseString);
     }
 
     public async Task<dynamic> GetReleaseVersionAsync()

--- a/XAU/Networking/GithubRestApi.cs
+++ b/XAU/Networking/GithubRestApi.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 public class GithubRestApi
@@ -47,12 +48,11 @@ public class GithubRestApi
         return jsonResponse;
     }
 
-    public async Task<dynamic> CheckForEventUpdatesAsync()
+    public async Task<EventsUpdateResponse?> CheckForEventUpdatesAsync()
     {
         SetDefaultHeaders();
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Host, Hosts.GitHubRaw);
         var responseString = await _httpClient.GetStringAsync("https://raw.githubusercontent.com/Fumo-Unlockers/Xbox-Achievement-Unlocker/Events-Data/meta.json");
-        var jsonResponse = (dynamic)JObject.Parse(responseString);
-        return jsonResponse;
+        return JsonConvert.DeserializeObject<EventsUpdateResponse>(responseString);
     }
 }

--- a/XAU/Networking/TrueAchievementRestApi.cs
+++ b/XAU/Networking/TrueAchievementRestApi.cs
@@ -22,7 +22,6 @@ public class TrueAchievementRestApi
         _httpClient.DefaultRequestHeaders.Clear();
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.AcceptEncoding, HeaderValues.AcceptEncoding);
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Accept, HeaderValues.Accept);
-
     }
 
     public async Task<Tuple<List<string>, List<string>>> SearchAsync(string searchText)

--- a/XAU/Networking/TrueAchievementRestApi.cs
+++ b/XAU/Networking/TrueAchievementRestApi.cs
@@ -99,7 +99,7 @@ public class TrueAchievementRestApi
                 {
                     foreach (var product in titleIDsContent.Products)
                     {
-                        if (product.Value.ProductType == "Game")
+                        if (product.Value.ProductType == "Game" && !string.IsNullOrWhiteSpace(product.Value.XboxTitleId))
                         {
                             return product.Value.XboxTitleId;
                         }

--- a/XAU/Networking/TrueAchievementRestApi.cs
+++ b/XAU/Networking/TrueAchievementRestApi.cs
@@ -105,6 +105,11 @@ public class TrueAchievementRestApi
                         }
                     }
                 }
+                else
+                {
+                    return xboxTitleId;
+                }
+
             }
         }
         return "-1";

--- a/XAU/Networking/TrueAchievementRestApi.cs
+++ b/XAU/Networking/TrueAchievementRestApi.cs
@@ -92,20 +92,17 @@ public class TrueAchievementRestApi
             }
             else
             {
-                var TitleIDsContent = await xboxApi.GetTitleIdsFromGamePass(productId);
-                var JsonTitleIDs = (dynamic)JObject.Parse(TitleIDsContent);
-                var xboxTitleId = JsonTitleIDs.Products[$"{productId}"].XboxTitleId;
+                var titleIDsContent = await xboxApi.GetTitleIdsFromGamePass(productId);
+                var xboxTitleId = titleIDsContent.Products[$"{productId}"].XboxTitleId;
                 //here is some super dumb shit to handle bundles
                 if (xboxTitleId == null)
                 {
-                    foreach (var Product in JsonTitleIDs.Products)
+                    foreach (var product in titleIDsContent.Products)
                     {
-                        foreach (var Title in Product)
+                        if (product.Value.ProductType == "Game")
                         {
-                            if (Title.ToString().Contains("\"ProductType\": \"Game\",") && Title.XboxTitleId != null)
-                            {
-                                return Title.XboxTitleId;
-                            }
+                            return product.Value.XboxTitleId;
+
                         }
                     }
                 }

--- a/XAU/Networking/TrueAchievementRestApi.cs
+++ b/XAU/Networking/TrueAchievementRestApi.cs
@@ -102,7 +102,6 @@ public class TrueAchievementRestApi
                         if (product.Value.ProductType == "Game")
                         {
                             return product.Value.XboxTitleId;
-
                         }
                     }
                 }

--- a/XAU/Networking/XboxRestApi.cs
+++ b/XAU/Networking/XboxRestApi.cs
@@ -78,7 +78,6 @@ public class XboxRestAPI
     public async Task<BasicProfile?> GetBasicProfileAsync()
     {
         SetDefaultHeaders();
-
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.ContractVersion, HeaderValues.ContractVersion2);
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Host, Hosts.Profile);
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Connection, HeaderValues.KeepAlive);

--- a/XAU/Networking/XboxRestApi.cs
+++ b/XAU/Networking/XboxRestApi.cs
@@ -248,8 +248,7 @@ public class XboxRestAPI
         await _eventBasedClient.PostAsync(BasicXboxAPIUris.TelemetryUrl, requestBody);
     }
 
-    // TODO: don't return dynamic....
-    public async Task<dynamic> GetTitleIdsFromGamePass(string prodId)
+    public async Task<GamePassProducts?> GetTitleIdsFromGamePass(string prodId)
     {
         SetDefaultHeaders();
         GamepassProductsRequest gamepassProducts = new GamepassProductsRequest()
@@ -259,6 +258,6 @@ public class XboxRestAPI
         var titleIDsResponse = await _httpClient.PostAsync(
                     BasicXboxAPIUris.GamepassCatalogUrl,
                     new StringContent(JsonConvert.SerializeObject(gamepassProducts))).Result.Content.ReadAsStringAsync();
-        return titleIDsResponse;
+        return JsonConvert.DeserializeObject<GamePassProducts>(titleIDsResponse);
     }
 }

--- a/XAU/Networking/XboxRestApi.cs
+++ b/XAU/Networking/XboxRestApi.cs
@@ -184,14 +184,14 @@ public class XboxRestAPI
         return achievements;
     }
 
-    public async Task<AchievementsResponse?> GetAchievementsFor360TitleAsync(string xuid, string titleId)
+    public async Task<Xbox360AchievementResponse?> GetAchievementsFor360TitleAsync(string xuid, string titleId)
     {
         SetDefaultHeaders();
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.ContractVersion, HeaderValues.ContractVersion3);
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Host, Hosts.Achievements);
         _httpClient.DefaultRequestHeaders.Add(HeaderNames.Connection, HeaderValues.KeepAlive);
         var response = await _httpClient.GetAsync(string.Format(InterpolatedXboxAPIUrls.QueryAchievements360Url, xuid, titleId)).Result.Content.ReadAsStringAsync();
-        var achievements = JsonConvert.DeserializeObject<AchievementsResponse>(response);
+        var achievements = JsonConvert.DeserializeObject<Xbox360AchievementResponse>(response);
         return achievements;
     }
 

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -75,12 +75,12 @@ namespace XAU.ViewModels.Pages
                     if (HomeViewModel.SpoofedTitleID == TitleIDOverride)
                     {
                         GameInfo = "Manually Spoofing";
-                        GameName = GameInfoResponse.Titles[0].Name.ToString();
+                        GameName = GameInfoResponse.Titles[0].Name;
                     }
                     else
                     {
                         GameInfo = "Spoofing Another Game";
-                        GameName = GameInfoResponse.Titles[0].Name.ToString();
+                        GameName = GameInfoResponse.Titles[0].Name;
                     }
 
                 }
@@ -133,7 +133,7 @@ namespace XAU.ViewModels.Pages
             try
             {
                 IsSelectedGame360 = GameInfoResponse.Titles[0].Devices.Contains("Xbox360") || GameInfoResponse.Titles[0].Devices.Contains("Mobile");
-                GameInfo = GameInfoResponse.Titles[0].Name.ToString();
+                GameInfo = GameInfoResponse.Titles[0].Name;
                 IsTitleIDValid = true;
             }
             catch
@@ -152,12 +152,12 @@ namespace XAU.ViewModels.Pages
                 if (HomeViewModel.SpoofedTitleID == TitleIDOverride)
                 {
                     GameInfo = "Manually Spoofing";
-                    GameName = GameInfoResponse.Titles[0].Name.ToString();
+                    GameName = GameInfoResponse.Titles[0].Name;
                 }
                 else
                 {
                     GameInfo = "Spoofing Another Game";
-                    GameName = GameInfoResponse.Titles[0].Name.ToString();
+                    GameName = GameInfoResponse.Titles[0].Name;
                 }
             }
             else
@@ -353,14 +353,14 @@ namespace XAU.ViewModels.Pages
             {
                 Unlockable = false;
                 AchievementResponse = await _xboxRestAPI.Value.GetAchievementsFor360TitleAsync(HomeViewModel.XUIDOnly, TitleIDOverride);
-                if (AchievementResponse.achievements.Count == 0)
+                if (AchievementResponse?.achievements.Count == 0)
                 {
                     _snackbarService.Show("Error: No Achievements", $"There were no achievements returned from the API", ControlAppearance.Danger,
                                                new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
                     return;
                 }
                 //cut down version of the code to display minimal information about 360 achievements
-                for (int i = 0; i < AchievementResponse.achievements.Count; i++)
+                for (int i = 0; i < AchievementResponse?.achievements.Count; i++)
                 {
                     var rewardnameplaceholder = "";
                     var rewarddescriptionplaceholder = "";

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -379,6 +379,10 @@ namespace XAU.ViewModels.Pages
                         value = Xbox360AchievementResponse.achievements[i].gamerscore.ToString(),
                         valueType = "N/a"
                     };
+                    var progression = new AchievementProgression
+                    {
+                        timeUnlocked = Xbox360AchievementResponse.achievements[i].timeUnlocked
+                    };
 
                     Achievements.Add(new OneCoreAchievementResponse()
                     {
@@ -388,7 +392,8 @@ namespace XAU.ViewModels.Pages
                         description = Xbox360AchievementResponse.achievements[i].description,
                         rewards = new List<AchievementRewards>()  {rewards},
                         raritycurrentCategory = Xbox360AchievementResponse.achievements[i].rarity.currentCategory,
-                        raritycurrentPercentage = Xbox360AchievementResponse.achievements[i].rarity.currentPercentage
+                        raritycurrentPercentage = Xbox360AchievementResponse.achievements[i].rarity.currentPercentage,
+                        progression = progression
                     }
                     );
                 }

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -374,15 +374,11 @@ namespace XAU.ViewModels.Pages
                 //cut down version of the code to display minimal information about 360 achievements
                 for (int i = 0; i < Xbox360AchievementResponse?.achievements.Count; i++)
                 {
-                    string rewardvalueTypeplaceholder;
-                    try
+                    var rewards = new AchievementRewards
                     {
-                        rewardvalueTypeplaceholder = Xbox360AchievementResponse.achievements[i].rewards[0].valueType;
-                    }
-                    catch
-                    {
-                        rewardvalueTypeplaceholder = "N/A";
-                    }
+                        value = Xbox360AchievementResponse.achievements[i].gamerscore.ToString(),
+                        valueType = "N/a"
+                    };
 
                     Achievements.Add(new OneCoreAchievementResponse()
                     {
@@ -390,8 +386,7 @@ namespace XAU.ViewModels.Pages
                         name = Xbox360AchievementResponse.achievements[i].name,
                         isSecret = Xbox360AchievementResponse.achievements[i].isSecret,
                         description = Xbox360AchievementResponse.achievements[i].description,
-                        rewardsvalue = Xbox360AchievementResponse.achievements[i].gamerscore.ToString(),
-                        rewardsvalueType = rewardvalueTypeplaceholder,
+                        rewards = new List<AchievementRewards>()  {rewards},
                         raritycurrentCategory = Xbox360AchievementResponse.achievements[i].rarity.currentCategory,
                         raritycurrentPercentage = Xbox360AchievementResponse.achievements[i].rarity.currentPercentage
                     }
@@ -650,9 +645,9 @@ namespace XAU.ViewModels.Pages
                     if (!IsSelectedGame360)
                     {
                         var gamerscore = 0;
-                        if (achievement.rewardstype == "Gamerscore")
+                        if (achievement.rewards[0].type == "Gamerscore")
                         {
-                            gamerscore = int.Parse(achievement.rewardsvalue);
+                            gamerscore = int.Parse(achievement.rewards[0].value);
                         }
                         DGAchievements.Add(new DGAchievement()
                         {
@@ -661,7 +656,7 @@ namespace XAU.ViewModels.Pages
                             Name = achievement.name,
                             Description = achievement.description,
                             IsSecret = achievement.isSecret,
-                            DateUnlocked = DateTime.Parse(achievement.progressiontimeUnlocked),
+                            DateUnlocked = DateTime.Parse(achievement.progression.timeUnlocked),
                             Gamerscore = gamerscore,
                             RarityPercentage = float.Parse(achievement.raritycurrentPercentage),
                             RarityCategory = achievement.raritycurrentCategory,
@@ -672,9 +667,9 @@ namespace XAU.ViewModels.Pages
                     else
                     {
                         var gamerscore = 0;
-                        if (achievement.rewardstype == StringConstants.Gamerscore)
+                        if (achievement.rewards[0].type == StringConstants.Gamerscore)
                         {
-                            gamerscore = int.Parse(achievement.rewardsvalue);
+                            gamerscore = int.Parse(achievement.rewards[0].value);
                         }
                         DGAchievements.Add(new DGAchievement()
                         {
@@ -683,7 +678,7 @@ namespace XAU.ViewModels.Pages
                             Name = achievement.name,
                             Description = achievement.description,
                             IsSecret = achievement.isSecret,
-                            DateUnlocked = DateTime.Parse(achievement.progressiontimeUnlocked),
+                            DateUnlocked = DateTime.Parse(achievement.progression.timeUnlocked),
                             Gamerscore = gamerscore,
                             RarityPercentage = float.Parse(achievement.raritycurrentPercentage),
                             RarityCategory = achievement.raritycurrentCategory,
@@ -714,9 +709,9 @@ namespace XAU.ViewModels.Pages
                     if (!IsSelectedGame360)
                     {
                         var gamerscore = 0;
-                        if (achievement.rewardstype == StringConstants.Gamerscore)
+                        if (achievement.rewards[0].type == StringConstants.Gamerscore)
                         {
-                            gamerscore = int.Parse(achievement.rewardsvalue);
+                            gamerscore = int.Parse(achievement.rewards[0].value);
                         }
                         DGAchievements.Add(new DGAchievement()
                         {
@@ -725,7 +720,7 @@ namespace XAU.ViewModels.Pages
                             Name = achievement.name,
                             Description = achievement.description,
                             IsSecret = achievement.isSecret,
-                            DateUnlocked = DateTime.Parse(achievement.progressiontimeUnlocked),
+                            DateUnlocked = DateTime.Parse(achievement.progression.timeUnlocked),
                             Gamerscore = gamerscore,
                             RarityPercentage = float.Parse(achievement.raritycurrentPercentage),
                             RarityCategory = achievement.raritycurrentCategory,
@@ -736,9 +731,9 @@ namespace XAU.ViewModels.Pages
                     else
                     {
                         var gamerscore = 0;
-                        if (achievement.rewardstype == StringConstants.Gamerscore)
+                        if (achievement.rewards[0].type == StringConstants.Gamerscore)
                         {
-                            gamerscore = int.Parse(achievement.rewardsvalue);
+                            gamerscore = int.Parse(achievement.rewards[0].value);
                         }
                         DGAchievements.Add(new DGAchievement()
                         {
@@ -747,7 +742,7 @@ namespace XAU.ViewModels.Pages
                             Name = achievement.name,
                             Description = achievement.description,
                             IsSecret = achievement.isSecret,
-                            DateUnlocked = DateTime.Parse(achievement.progressiontimeUnlocked),
+                            DateUnlocked = DateTime.Parse(achievement.progression.timeUnlocked),
                             Gamerscore = gamerscore,
                             RarityPercentage = float.Parse(achievement.raritycurrentPercentage),
                             RarityCategory = achievement.raritycurrentCategory,

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -492,7 +492,7 @@ namespace XAU.ViewModels.Pages
                     DGAchievements[AchievementIndex].DateUnlocked = DateTime.Now;
                     CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
                 }
-                catch (HttpRequestException)
+                catch (HttpRequestException ex)
                 {
                     _snackbarService.Show("Error: Achievement Not Unlocked",
                         $"{DGAchievements[AchievementIndex].Name} was not unlocked", ControlAppearance.Danger,

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -292,13 +292,7 @@ namespace XAU.ViewModels.Pages
                         titleAssociationsname = AchievementResponse.achievements[i].titleAssociations[0].name,
                         titleAssociationsid = AchievementResponse.achievements[i].titleAssociations[0].id,
                         progressState = AchievementResponse.achievements[i].progressState,
-                        //these are strings because im too lazy to handle them properly right now
-                        progressionrequirementsid = "AchievementResponse.achievements[i].progression.requirements[0].id",
-                        progressionrequirementscurrent = "AchievementResponse.achievements[i].progression.requirements[0].current",
-                        progressionrequirementstarget = "AchievementResponse.achievements[i].progression.requirements[0].target",
-                        progressionrequirementsoperationType = "AchievementResponse.achievements[i].progression.requirements[0].operationType",
-                        progressionrequirementsvalueType = "AchievementResponse.achievements[i].progression.requirements[0].valueType",
-                        progressionrequirementsruleParticipationType = "AchievementResponse.achievements[i].progression.requirements[0].ruleParticipationType",
+
                         progressiontimeUnlocked = AchievementResponse.achievements[i].progression.timeUnlocked,
                         mediaAssetsname = AchievementResponse.achievements[i].mediaAssets[0].name,
                         mediaAssetstype = AchievementResponse.achievements[i].mediaAssets[0].type,
@@ -374,17 +368,10 @@ namespace XAU.ViewModels.Pages
                     Achievements.Add(new AchievementEntryResponse()
                     {
                         id = AchievementResponse.achievements[i].id,
-                        serviceConfigId = "Null",
                         name = AchievementResponse.achievements[i].name,
-                        progressState = "Null",
-                        progressiontimeUnlocked = "0001-01-01T00:00:00.0000000Z",
                         isSecret = AchievementResponse.achievements[i].isSecret,
                         description = AchievementResponse.achievements[i].description,
-                        rewardsname = "Null",
-                        rewardsdescription = "Null",
                         rewardsvalue = AchievementResponse.achievements[i].gamerscore.ToString(),
-                        rewardstype = "Gamerscore",
-                        rewardsmediaAsset = "Null",
                         rewardsvalueType = rewardvalueTypeplaceholder,
                         raritycurrentCategory = AchievementResponse.achievements[i].rarity.currentCategory,
                         raritycurrentPercentage = AchievementResponse.achievements[i].rarity.currentPercentage

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -56,14 +56,14 @@ namespace XAU.ViewModels.Pages
         {
             public int Index { get; set; }
             public int ID { get; set; }
-            public string Name { get; set; }
-            public string Description { get; set; }
-            public string IsSecret { get; set; }
+            public string? Name { get; set; }
+            public string? Description { get; set; }
+            public string? IsSecret { get; set; }
             public DateTime DateUnlocked { get; set; }
             public int Gamerscore { get; set; }
             public float RarityPercentage { get; set; }
-            public string RarityCategory { get; set; }
-            public string ProgressState { get; set; }
+            public string? RarityCategory { get; set; }
+            public string? ProgressState { get; set; }
             public bool IsUnlockable { get; set; }
         }
         public async void OnNavigatedTo()

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -6,7 +6,6 @@ using System.Windows.Data;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Wpf.Ui.Controls;
-using System.Text.RegularExpressions;
 using Wpf.Ui.Common;
 using Wpf.Ui.Contracts;
 using Wpf.Ui.Services;

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -361,28 +361,13 @@ namespace XAU.ViewModels.Pages
                 //cut down version of the code to display minimal information about 360 achievements
                 for (int i = 0; i < AchievementResponse?.achievements.Count; i++)
                 {
-                    var rewardnameplaceholder = "";
-                    var rewarddescriptionplaceholder = "";
-                    var rewardvalueplaceholder = "";
-                    var rewardtypeplaceholder = "";
-                    var rewardmediaAssetplaceholder = "";
-                    var rewardvalueTypeplaceholder = "";
+                    string rewardvalueTypeplaceholder;
                     try
                     {
-                        rewardnameplaceholder = AchievementResponse.achievements[i].rewards[0].name;
-                        rewarddescriptionplaceholder = AchievementResponse.achievements[i].rewards[0].description;
-                        rewardvalueplaceholder = AchievementResponse.achievements[i].rewards[0].value;
-                        rewardtypeplaceholder = AchievementResponse.achievements[i].rewards[0].type;
-                        //rewardmediaAssetplaceholder = AchievementResponse.achievements[i].rewards[0].mediaAsset;
                         rewardvalueTypeplaceholder = AchievementResponse.achievements[i].rewards[0].valueType;
                     }
                     catch
                     {
-                        rewardnameplaceholder = "N/A";
-                        rewarddescriptionplaceholder = "N/A";
-                        rewardvalueplaceholder = "N/A";
-                        rewardtypeplaceholder = "N/A";
-                        rewardmediaAssetplaceholder = "N/A";
                         rewardvalueTypeplaceholder = "N/A";
                     }
 

--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -164,19 +164,19 @@ namespace XAU.ViewModels.Pages
                 HomeViewModel.AutoSpoofedTitleID = TitleIDOverride;
                 HomeViewModel.SpoofingStatus = 2;
                 GameInfo = "Auto Spoofing";
-                GameName = GameInfoResponse.Titles[0].Name.ToString();
+                GameName = GameInfoResponse.Titles[0].Name;
                 await Task.Run(() => Spoofing());
                 if (HomeViewModel.SpoofingStatus == 1)
                 {
                     if (HomeViewModel.SpoofedTitleID == HomeViewModel.AutoSpoofedTitleID)
                     {
                         GameInfo = "Manually Spoofing";
-                        GameName = GameInfoResponse.Titles[0].Name.ToString();
+                        GameName = GameInfoResponse.Titles[0].Name;
                     }
                     else
                     {
                         GameInfo = "Spoofing Another Game";
-                        GameName = GameInfoResponse.Titles[0].Name.ToString();
+                        GameName = GameInfoResponse.Titles[0].Name;
                     }
                 }
                 HomeViewModel.AutoSpoofedTitleID = "0";
@@ -449,7 +449,7 @@ namespace XAU.ViewModels.Pages
                     EventsData = (dynamic)(JObject)data[TitleIDOverride];
                     foreach (var achievement in DGAchievements)
                     {
-                        if (EventsData.Achievements.ContainsKey(achievement.ID.ToString()) && achievement.ProgressState != StringConstants.Achieved)
+                        if (EventsData.Achievements.ContainsKey(achievement.ID) && achievement.ProgressState != StringConstants.Achieved)
                         {
                             achievement.IsUnlockable = true;
                         }
@@ -483,7 +483,7 @@ namespace XAU.ViewModels.Pages
             {
                 try
                 {
-                    await _xboxRestAPI.Value.UnlockTitleBasedAchievementAsync(AchievementResponse.achievements[0].serviceConfigId.ToString(), AchievementResponse.achievements[0].titleAssociations[0].id.ToString(), HomeViewModel.XUIDOnly, DGAchievements[AchievementIndex].ID.ToString(), HomeViewModel.Settings.FakeSignatureEnabled);
+                    await _xboxRestAPI.Value.UnlockTitleBasedAchievementAsync(AchievementResponse.achievements[0].serviceConfigId, AchievementResponse.achievements[0].titleAssociations[0].id, HomeViewModel.XUIDOnly, DGAchievements[AchievementIndex].ID.ToString(), HomeViewModel.Settings.FakeSignatureEnabled);
 
                     _snackbarService.Show("Achievement Unlocked", $"{DGAchievements[AchievementIndex].Name} has been unlocked",
                         ControlAppearance.Success, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
@@ -492,7 +492,7 @@ namespace XAU.ViewModels.Pages
                     DGAchievements[AchievementIndex].DateUnlocked = DateTime.Now;
                     CollectionViewSource.GetDefaultView(DGAchievements).Refresh();
                 }
-                catch (HttpRequestException ex)
+                catch (HttpRequestException)
                 {
                     _snackbarService.Show("Error: Achievement Not Unlocked",
                         $"{DGAchievements[AchievementIndex].Name} was not unlocked", ControlAppearance.Danger,
@@ -511,14 +511,14 @@ namespace XAU.ViewModels.Pages
                 // TODO: move this over to the rest api?
                 var requestbody = File.ReadAllText(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + $"\\XAU\\Events\\{TitleIDOverride}.json");
                 DateTime timestamp = DateTime.UtcNow;
-                foreach (var i in EventsData.Achievements[DGAchievements[AchievementIndex].ID.ToString()])
+                foreach (var i in EventsData.Achievements[DGAchievements[AchievementIndex].ID])
                 {
                     var ReplacementData = i.Value;
-                    switch (ReplacementData.ReplacementType.ToString())
+                    switch (ReplacementData.ReplacementType)
                     {
                         case "Replace":
                             {
-                                requestbody = requestbody.Replace(ReplacementData.Target.ToString(), ReplacementData.Replacement.ToString());
+                                requestbody = requestbody.Replace(ReplacementData.Target, ReplacementData.Replacement);
                                 break;
                             }
                         case "RangeInt":

--- a/XAU/ViewModels/Pages/GamesViewModel.cs
+++ b/XAU/ViewModels/Pages/GamesViewModel.cs
@@ -94,7 +94,7 @@ namespace XAU.ViewModels.Pages
         }
         public async Task OpenAchievements(string index)
         {
-            AchievementsViewModel.TitleID = GamesResponse.Titles[int.Parse(index)].TitleId.ToString();
+            AchievementsViewModel.TitleID = GamesResponse.Titles[int.Parse(index)].TitleId;
             AchievementsViewModel.IsSelectedGame360 = GamesResponse.Titles[int.Parse(index)].Devices.Contains("Xbox360") || GamesResponse.Titles[int.Parse(index)].Devices.Contains("Mobile");
             AchievementsViewModel.NewGame = true;
             navigationService.Navigate(typeof(AchievementsPage));
@@ -137,7 +137,7 @@ namespace XAU.ViewModels.Pages
                         {
                             if (GamesResponse.Titles[i].Devices.Contains("Xbox360"))
                             {
-                                if (!GamesResponse.Titles[i].Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }
@@ -148,7 +148,7 @@ namespace XAU.ViewModels.Pages
                         {
                             if (GamesResponse.Titles[i].Devices.Contains("Win32"))
                             {
-                                if (!GamesResponse.Titles[i].Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             };
@@ -260,7 +260,7 @@ namespace XAU.ViewModels.Pages
                         {
                             if (double.TryParse(GamesResponse.Titles[i].Achievement.ProgressPercentage.ToString(), out double progress) && progress < 100)
                             {
-                                if (!GamesResponse.Titles[i].Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }

--- a/XAU/ViewModels/Pages/GamesViewModel.cs
+++ b/XAU/ViewModels/Pages/GamesViewModel.cs
@@ -113,10 +113,9 @@ namespace XAU.ViewModels.Pages
                     case 1:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("XboxSeries") || title.Devices.Contains("XboxOne"))
+                            if (GamesResponse.Titles[i].Devices.Contains("XboxSeries") || GamesResponse.Titles[i].Devices.Contains("XboxOne"))
                             {
-                                if (!title.Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }
@@ -125,10 +124,9 @@ namespace XAU.ViewModels.Pages
                     case 2:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("PC"))
+                            if (GamesResponse.Titles[i].Devices.Contains("PC"))
                             {
-                                if (!title.Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }
@@ -137,10 +135,9 @@ namespace XAU.ViewModels.Pages
                     case 3:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("Xbox360"))
+                            if (GamesResponse.Titles[i].Devices.Contains("Xbox360"))
                             {
-                                if (!title.Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToString().ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }
@@ -149,10 +146,9 @@ namespace XAU.ViewModels.Pages
                     case 4:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("Win32"))
+                            if (GamesResponse.Titles[i].Devices.Contains("Win32"))
                             {
-                                if (!title.Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToString().ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             };
@@ -161,10 +157,9 @@ namespace XAU.ViewModels.Pages
                     case 5:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (double.TryParse(title.Achievement.ProgressPercentage.ToString(), out double progress) && progress < 100)
+                            if (double.TryParse(GamesResponse.Titles[i].Achievement.ProgressPercentage.ToString(), out double progress) && progress < 100)
                             {
-                                if (!title.Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }
@@ -235,42 +230,37 @@ namespace XAU.ViewModels.Pages
                     case 1:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("XboxSeries") || title.Devices.Contains("XboxOne"))
+                            if (GamesResponse.Titles[i].Devices.Contains("XboxSeries") || GamesResponse.Titles[i].Devices.Contains("XboxOne"))
                                 AddGame(i);
                         }
                         break;
                     case 2:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("PC"))
+                            if (GamesResponse.Titles[i].Devices.Contains("PC"))
                                 AddGame(i);
                         }
                         break;
                     case 3:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("Xbox360"))
+                            if (GamesResponse.Titles[i].Devices.Contains("Xbox360"))
                                 AddGame(i);
                         }
                         break;
                     case 4:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (title.Devices.Contains("Win32"))
+                            if (GamesResponse.Titles[i].Devices.Contains("Win32"))
                                 AddGame(i);
                         }
                         break;
                     case 5:
                         for (int i = 0; i < GamesResponse.Titles.Count; i++)
                         {
-                            dynamic title = GamesResponse.Titles[i];
-                            if (double.TryParse(title.Achievement.ProgressPercentage.ToString(), out double progress) && progress < 100)
+                            if (double.TryParse(GamesResponse.Titles[i].Achievement.ProgressPercentage.ToString(), out double progress) && progress < 100)
                             {
-                                if (!title.Name.ToString().ToLower().Contains(SearchText.ToLower()))
+                                if (!GamesResponse.Titles[i].Name.ToString().ToLower().Contains(SearchText.ToLower()))
                                     continue;
                                 AddGame(i);
                             }

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -467,7 +467,7 @@ namespace XAU.ViewModels.Pages
                     AccountTier = $"Tier: {profileResponse.People[0].Detail?.AccountTier}";
                     try
                     {
-                        if (!profileResponse.People[0].PresenceDetails.Any())
+                        if (!profileResponse.People[0].PresenceDetails.Any() || profileResponse.People[0].PresenceDetails[0].TitleId == null)
                         {
                             CurrentlyPlaying = $"Currently Playing: Unknown (No Presence)";
                         }
@@ -506,35 +506,38 @@ namespace XAU.ViewModels.Pages
                     }
 
                     ActiveDevice = $"Active Device: {profileResponse.People[0].PresenceDetails[0].Device}";
-                    IsVerified = $"Verified: {profileResponse.People[0].Detail.IsVerified}";
-                    Location = $"Location: {profileResponse.People[0].Detail.Location}";
-                    Tenure = $"Tenure: {profileResponse.People[0].Detail.Tenure}";
-                    Following = $"Following: {profileResponse.People[0].Detail.FollowingCount}";
-                    Followers = $"Followers: {profileResponse.People[0].Detail.FollowerCount}";
-                    Bio = $"Bio: {profileResponse.People[0].Detail.Bio}";
-
-                    Watermarks.Clear();
-
-                    // Tenure image format, 01..05..10
-                    // https://dlassets-ssl.xboxlive.com/public/content/ppl/watermarks/tenure/15.png
-                    // https://dlassets-ssl.xboxlive.com/public/content/ppl/watermarks/launch/ba75b64a-9a80-47ea-8c3a-76d3e2ea1422.png
-                    // https://dlassets-ssl.xboxlive.com/public/content/ppl/watermarks/launch/xboxoneteam.png
-                    var tenureString = profileResponse.People[0].Detail.Tenure;
-                    if (int.TryParse(tenureString, out int tenureInt))
+                    if (profileResponse.People[0].Detail != null)
                     {
-                        // Format the integer as a two-digit string
-                        string tenureBadge = tenureInt.ToString("D2");
-                        Watermarks.Add(new ImageItem { ImageUrl = $@"{BasicXboxAPIUris.WatermarksUrl}tenure/{tenureBadge}.png" });
-                    }
-                    else
-                    {
-                        // TODO: log error somewhere
-                        Console.WriteLine("The string is not a valid integer.");
-                    }
+                        IsVerified = $"Verified: {profileResponse.People[0].Detail.IsVerified}";
+                        Location = $"Location: {profileResponse.People[0].Detail.Location}";
+                        Tenure = $"Tenure: {profileResponse.People[0].Detail.Tenure}";
+                        Following = $"Following: {profileResponse.People[0].Detail.FollowingCount}";
+                        Followers = $"Followers: {profileResponse.People[0].Detail.FollowerCount}";
+                        Bio = $"Bio: {profileResponse.People[0].Detail.Bio}";
 
-                    foreach (var watermark in profileResponse.People[0].Detail.Watermarks)
-                    {
-                        Watermarks.Add(new ImageItem { ImageUrl = $@"{BasicXboxAPIUris.WatermarksUrl}launch/{watermark.ToLower()}.png" });
+                        Watermarks.Clear();
+
+                        // Tenure image format, 01..05..10
+                        // https://dlassets-ssl.xboxlive.com/public/content/ppl/watermarks/tenure/15.png
+                        // https://dlassets-ssl.xboxlive.com/public/content/ppl/watermarks/launch/ba75b64a-9a80-47ea-8c3a-76d3e2ea1422.png
+                        // https://dlassets-ssl.xboxlive.com/public/content/ppl/watermarks/launch/xboxoneteam.png
+                        var tenureString = profileResponse.People[0].Detail.Tenure;
+                        if (int.TryParse(tenureString, out int tenureInt))
+                        {
+                            // Format the integer as a two-digit string
+                            string tenureBadge = tenureInt.ToString("D2");
+                            Watermarks.Add(new ImageItem { ImageUrl = $@"{BasicXboxAPIUris.WatermarksUrl}tenure/{tenureBadge}.png" });
+                        }
+                        else
+                        {
+                            // TODO: log error somewhere
+                            Console.WriteLine("The string is not a valid integer.");
+                        }
+
+                        foreach (var watermark in profileResponse.People[0].Detail.Watermarks)
+                        {
+                            Watermarks.Add(new ImageItem { ImageUrl = $@"{BasicXboxAPIUris.WatermarksUrl}launch/{watermark.ToLower()}.png" });
+                        }
                     }
                 }
                 GrabbedProfile = true;

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -32,21 +32,21 @@ namespace XAU.ViewModels.Pages
         [ObservableProperty] private Brush _loggedInColor = new SolidColorBrush(Colors.Red);
 
         //profile vars
-        [ObservableProperty] private string _gamerPic = "pack://application:,,,/Assets/cirno.png";
-        [ObservableProperty] private string _gamerTag = "Gamertag: Unknown   ";
-        [ObservableProperty] private string _xuid = "XUID: Unknown";
-        [ObservableProperty] private string _gamerScore = "Gamerscore: Unknown";
-        [ObservableProperty] private string _profileRep = "Reputation: Unknown";
-        [ObservableProperty] private string _accountTier = "Tier: Unknown";
-        [ObservableProperty] private string _currentlyPlaying = "Currently Playing: Unknown";
-        [ObservableProperty] private string _activeDevice = "Active Device: Unknown";
-        [ObservableProperty] private string _isVerified = "Verified: Unknown";
-        [ObservableProperty] private string _location = "Location: Unknown";
-        [ObservableProperty] private string _tenure = "Tenure: Unknown";
-        [ObservableProperty] private string _following = "Following: Unknown";
-        [ObservableProperty] private string _followers = "Followers: Unknown";
-        [ObservableProperty] private string _gamepass = "Gamepass: Unknown";
-        [ObservableProperty] private string _bio = "Bio: Unknown";
+        [ObservableProperty] private string? _gamerPic = "pack://application:,,,/Assets/cirno.png";
+        [ObservableProperty] private string? _gamerTag = "Gamertag: Unknown   ";
+        [ObservableProperty] private string? _xuid = "XUID: Unknown";
+        [ObservableProperty] private string? _gamerScore = "Gamerscore: Unknown";
+        [ObservableProperty] private string? _profileRep = "Reputation: Unknown";
+        [ObservableProperty] private string? _accountTier = "Tier: Unknown";
+        [ObservableProperty] private string? _currentlyPlaying = "Currently Playing: Unknown";
+        [ObservableProperty] private string? _activeDevice = "Active Device: Unknown";
+        [ObservableProperty] private string? _isVerified = "Verified: Unknown";
+        [ObservableProperty] private string? _location = "Location: Unknown";
+        [ObservableProperty] private string? _tenure = "Tenure: Unknown";
+        [ObservableProperty] private string? _following = "Following: Unknown";
+        [ObservableProperty] private string? _followers = "Followers: Unknown";
+        [ObservableProperty] private string? _gamepass = "Gamepass: Unknown";
+        [ObservableProperty] private string? _bio = "Bio: Unknown";
         [ObservableProperty] public static bool _isLoggedIn = false;
         [ObservableProperty] public static bool _updateAvaliable = false;
         [ObservableProperty] private ObservableCollection<ImageItem> _watermarks = new ObservableCollection<ImageItem>();

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -432,6 +432,11 @@ namespace XAU.ViewModels.Pages
             try
             {
                 var profileResponse = await _xboxRestAPI.Value.GetProfileAsync(XUIDOnly);
+                if (profileResponse == null || !profileResponse.People.Any())
+                {
+                    _snackbarService.Show("Error", "Failed to grab profile information.", ControlAppearance.Danger, new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+                    return;
+                }
 
                 if (Settings.PrivacyMode)
                 {
@@ -453,15 +458,16 @@ namespace XAU.ViewModels.Pages
                 }
                 else
                 {
+
                     GamerTag = $"Gamertag: {profileResponse.People[0].Gamertag}";
                     Xuid = $"XUID: {profileResponse.People[0].Xuid}";
                     GamerPic = profileResponse.People[0].DisplayPicRaw;
                     GamerScore = $"Gamerscore: {profileResponse.People[0].GamerScore}";
                     ProfileRep = $"Reputation: {profileResponse.People[0].XboxOneRep}";
-                    AccountTier = $"Tier: {profileResponse.People[0].Detail.AccountTier}";
+                    AccountTier = $"Tier: {profileResponse.People[0].Detail?.AccountTier}";
                     try
                     {
-                        if (profileResponse.People[0].PresenceDetails.Count == 0)
+                        if (!profileResponse.People[0].PresenceDetails.Any())
                         {
                             CurrentlyPlaying = $"Currently Playing: Unknown (No Presence)";
                         }

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -261,7 +261,7 @@ namespace XAU.ViewModels.Pages
                 {
                     Directory.CreateDirectory(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "XAU\\Events"));
                 }
-                var defaultSettings = new
+                var defaultSettings = new XAUSettings
                 {
                     SettingsVersion = "1",
                     ToolVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(),
@@ -551,19 +551,7 @@ namespace XAU.ViewModels.Pages
 
         #region Settings
 
-        public class SettingsList
-        {
-            public string SettingsVersion { get; set; }
-            public string ToolVersion { get; set; }
-            public bool UnlockAllEnabled { get; set; }
-            public bool AutoSpooferEnabled { get; set; }
-            public bool AutoLaunchXboxAppEnabled { get; set; }
-            public bool FakeSignatureEnabled { get; set; }
-            public bool RegionOverride { get; set; }
-            public bool UseAcrylic { get; set; }
-            public bool PrivacyMode { get; set; }
-        }
-        public static SettingsList Settings = new SettingsList();
+        public static XAUSettings Settings = new XAUSettings();
 
         public void LoadSettings()
         {

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -161,7 +161,7 @@ namespace XAU.ViewModels.Pages
         {
             if (EventsVersion == "EmptyDevEventsVersion")
                 return;
-            var jsonResponse = await _gitHubRestAPI.Value.CheckForEventUpdatesAsync();
+            var response = await _gitHubRestAPI.Value.CheckForEventUpdatesAsync();
             var EventsTimestamp = 0;
             if (File.Exists(EventsMetaFilePath))
             {
@@ -170,7 +170,7 @@ namespace XAU.ViewModels.Pages
                 EventsTimestamp = meta.Timestamp;
             }
 
-            if (jsonResponse.Timestamp > EventsTimestamp && jsonResponse.DataVersion == EventsVersion)
+            if (response.Timestamp > EventsTimestamp && response.DataVersion == EventsVersion)
             {
                 _snackbarService.Show("Downloading Events Update...", "Please wait", ControlAppearance.Info, new SymbolIcon(SymbolRegular.Checkmark24), _snackbarDuration);
                 UpdateEvents();

--- a/XAU/ViewModels/Pages/HomeViewModel.cs
+++ b/XAU/ViewModels/Pages/HomeViewModel.cs
@@ -166,7 +166,7 @@ namespace XAU.ViewModels.Pages
             if (File.Exists(EventsMetaFilePath))
             {
                 var metaJson = File.ReadAllText(EventsMetaFilePath);
-                var meta = JsonConvert.DeserializeObject<dynamic>(metaJson);
+                var meta = JsonConvert.DeserializeObject<EventsUpdateResponse>(metaJson);
                 EventsTimestamp = meta.Timestamp;
             }
 
@@ -568,7 +568,7 @@ namespace XAU.ViewModels.Pages
         public void LoadSettings()
         {
             string settingsJson = File.ReadAllText(SettingsFilePath);
-            var settings = JsonConvert.DeserializeObject<dynamic>(settingsJson);
+            var settings = JsonConvert.DeserializeObject<XAUSettings>(settingsJson);
             Settings.SettingsVersion = settings.SettingsVersion;
             Settings.ToolVersion = settings.ToolVersion;
             Settings.UnlockAllEnabled = settings.UnlockAllEnabled;

--- a/XAU/ViewModels/Pages/MiscViewModel.cs
+++ b/XAU/ViewModels/Pages/MiscViewModel.cs
@@ -51,7 +51,7 @@ namespace XAU.ViewModels.Pages
         [ObservableProperty] private string _gameGamepass = "Gamepass: ";
         [ObservableProperty] private string _gameDevices = "Devices: ";
         [ObservableProperty] private string _gameGamerscore = "Gamerscore: ?/?";
-        [ObservableProperty] private string _gameImage = "pack://application:,,,/Assets/cirno.png";
+        [ObservableProperty] private string? _gameImage = "pack://application:,,,/Assets/cirno.png";
         [ObservableProperty] private string _gameTime = "Time Played: ";
         [ObservableProperty] private bool _isInitialized = false;
         [ObservableProperty] private string _currentSpoofingID = "";
@@ -103,14 +103,22 @@ namespace XAU.ViewModels.Pages
             GameInfoResponse = await _xboxRestAPI.Value.GetGameTitleAsync(HomeViewModel.XUIDOnly, NewSpoofingID);
             GameStatsResponse = await _xboxRestAPI.Value.GetGameStatsAsync(HomeViewModel.XUIDOnly, NewSpoofingID);
 
+            if (GameInfoResponse == null || GameStatsResponse == null) {
+                _snackbarService.Show("Error: Unable to acquire game info or stats",
+                    $"The game info was invalid.",
+                    ControlAppearance.Danger,
+                    new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
+                return;
+            }
+
             try
             {
-                GameName = "Name: " + GameInfoResponse.Titles[0].Name.ToString();
-                GameImage = GameInfoResponse.Titles[0].DisplayImage.ToString();
-                GameTitleID = "Title ID: " + GameInfoResponse.Titles[0].TitleId.ToString();
-                GamePFN = "PFN: " + GameInfoResponse.Titles[0].Pfn.ToString();
-                GameType = "Type: " + GameInfoResponse.Titles[0].Type.ToString();
-                GameGamepass = "Gamepass: " + GameInfoResponse.Titles[0].GamePass.IsGamePass.ToString();
+                GameName = "Name: " + GameInfoResponse.Titles[0].Name;
+                GameImage = GameInfoResponse.Titles[0].DisplayImage;
+                GameTitleID = "Title ID: " + GameInfoResponse.Titles[0].TitleId;
+                GamePFN = "PFN: " + GameInfoResponse.Titles[0].Pfn;
+                GameType = "Type: " + GameInfoResponse.Titles[0].Type;
+                GameGamepass = "Gamepass: " + GameInfoResponse.Titles[0].GamePass?.IsGamePass;
                 GameDevices = "Devices: ";
                 foreach (var device in GameInfoResponse.Titles[0].Devices)
                 {
@@ -118,8 +126,8 @@ namespace XAU.ViewModels.Pages
                 }
 
                 GameDevices = GameDevices.Remove(GameDevices.Length - 2);
-                GameGamerscore = "Gamerscore: " + GameInfoResponse.Titles[0].Achievement.CurrentGamerscore.ToString() +
-                                 "/" + GameInfoResponse.Titles[0].Achievement.TotalGamerscore.ToString();
+                GameGamerscore = "Gamerscore: " + GameInfoResponse.Titles[0].Achievement?.CurrentGamerscore.ToString() +
+                                 "/" + GameInfoResponse.Titles[0].Achievement?.TotalGamerscore.ToString();
                 try
                 {
                     var timePlayed = TimeSpan.FromMinutes(Convert.ToDouble(GameStatsResponse.StatListsCollection[0].Stats[0].Value));
@@ -145,7 +153,7 @@ namespace XAU.ViewModels.Pages
             SpoofingUpdate = true;
             CurrentlySpoofing = true;
             SpoofingButtonText = "Stop Spoofing";
-            SpoofingText = $"Spoofing {GameInfoResponse.Titles[0].Name.ToString()}";
+            SpoofingText = $"Spoofing {GameInfoResponse.Titles[0].Name}";
             await Task.Run(() => Spoofing());
 
         }
@@ -177,7 +185,7 @@ namespace XAU.ViewModels.Pages
                         break;
                     }
                     spoofingTime = stopwatch.Elapsed;
-                    SpoofingText = $"Spoofing {GameInfoResponse.Titles[0].Name.ToString()} For: {spoofingTime.ToString(@"hh\:mm\:ss")}";
+                    SpoofingText = $"Spoofing {GameInfoResponse.Titles[0].Name} For: {spoofingTime.ToString(@"hh\:mm\:ss")}";
                     i++;
                 }
                 Thread.Sleep(1000);

--- a/XAU/ViewModels/Pages/MiscViewModel.cs
+++ b/XAU/ViewModels/Pages/MiscViewModel.cs
@@ -103,7 +103,8 @@ namespace XAU.ViewModels.Pages
             GameInfoResponse = await _xboxRestAPI.Value.GetGameTitleAsync(HomeViewModel.XUIDOnly, NewSpoofingID);
             GameStatsResponse = await _xboxRestAPI.Value.GetGameStatsAsync(HomeViewModel.XUIDOnly, NewSpoofingID);
 
-            if (GameInfoResponse == null || GameStatsResponse == null) {
+            if (GameInfoResponse == null || GameStatsResponse == null)
+            {
                 _snackbarService.Show("Error: Unable to acquire game info or stats",
                     $"The game info was invalid.",
                     ControlAppearance.Danger,

--- a/XAU/ViewModels/Pages/SettingsViewModel.cs
+++ b/XAU/ViewModels/Pages/SettingsViewModel.cs
@@ -30,7 +30,7 @@ namespace XAU.ViewModels.Pages
         [RelayCommand]
         public void SaveSettings()
         {
-            var settings = new
+            var settings = new XAUSettings
             {
                 SettingsVersion = SettingsVersion,
                 ToolVersion = ToolVersion,
@@ -45,15 +45,7 @@ namespace XAU.ViewModels.Pages
             };
             string settingsJson = JsonConvert.SerializeObject(settings);
             File.WriteAllText(SettingsFilePath, settingsJson);
-            HomeViewModel.Settings.SettingsVersion = SettingsVersion;
-            HomeViewModel.Settings.ToolVersion = ToolVersion;
-            HomeViewModel.Settings.UnlockAllEnabled = UnlockAllEnabled;
-            HomeViewModel.Settings.AutoSpooferEnabled = AutoSpooferEnabled;
-            HomeViewModel.Settings.AutoLaunchXboxAppEnabled = AutoLaunchXboxAppEnabled;
-            HomeViewModel.Settings.FakeSignatureEnabled = FakeSignatureEnabled;
-            HomeViewModel.Settings.RegionOverride = RegionOverride;
-            HomeViewModel.Settings.UseAcrylic = UseAcrylic;
-            HomeViewModel.Settings.PrivacyMode = PrivacyMode;
+            HomeViewModel.Settings = settings; // update ref
         }
 
         public void OnNavigatedTo()
@@ -86,6 +78,7 @@ namespace XAU.ViewModels.Pages
             PrivacyMode = HomeViewModel.Settings.PrivacyMode;
             Xauth = HomeViewModel.XAUTH;
         }
+
         private string GetAssemblyVersion()
         {
             return System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString()


### PR DESCRIPTION
- Begin cleaning up Xbox Achievement VM (this is taking some time, lots of dupe)
- Fixes time window issue (for games with Challenges)
- Removed more dynamic code (and fixed the search after breaking it :-))
- Chunked a large part out of the warnings
- Give spoofer its own client

:heavy_check_mark: Profile Details 
:heavy_check_mark: Manual Spoof
:heavy_check_mark: Auto Spoof 
:heavy_check_mark: Get Achievement Lists for Xbox Title and 360 
:heavy_check_mark:  UnlockAll (Tested w/ large list, halo infinite)
:heavy_check_mark: EventBased (Gears 4 tested)
:heavy_check_mark: Title ID Search (empty, halo, halo 3)
:heavy_check_mark: Game Search (empty, games I don't have, dead space)
:heavy_check_mark:  Drag Window (ensure theme issue doesn't occur)
:heavy_check_mark: Achievement Search  (empty, achievements I have, achievements I don't have)
:heavy_check_mark: Update / Github Flow
:heavy_check_mark: Privacy
:heavy_check_mark: Copy to Clipboard