### PR TITLE
Sorry Draff. fix auto-spoofer bug 

### DIFF
--- a/XAU/ViewModels/Pages/AchievementsViewModel.cs
+++ b/XAU/ViewModels/Pages/AchievementsViewModel.cs
@@ -71,7 +71,8 @@ namespace XAU.ViewModels.Pages
         {
             if (HomeViewModel.Settings.AutoSpooferEnabled)
             {
-                if (!GameInfoResponse.Titles.Any())
+
+                if (!GameInfoResponse.Titles.Any() && !String.IsNullOrWhiteSpace(GameInfoResponse.Xuid))
                 {
                     _snackbarService.Show("Error: Game Info Response Contained No Titles", $"There were no titles returned from the API", ControlAppearance.Danger,
                         new SymbolIcon(SymbolRegular.ErrorCircle24), _snackbarDuration);
@@ -179,7 +180,11 @@ namespace XAU.ViewModels.Pages
                 HomeViewModel.AutoSpoofedTitleID = TitleIDOverride;
                 HomeViewModel.SpoofingStatus = 2;
                 GameInfo = "Auto Spoofing";
-                GameName = GameInfoResponse.Titles[0].Name;
+                if (GameInfoResponse.Titles.Any())
+                {
+                    GameName = GameInfoResponse.Titles[0].Name;
+                }
+
                 await Task.Run(() => Spoofing());
                 if (HomeViewModel.SpoofingStatus == 1)
                 {


### PR DESCRIPTION
- Bug: Autospoofer apparently loads before the game info is ever loaded (OnNavigatedTo), so current Main build will 'oopsy woopsy' but not fail out 
- This checks to see if GameInfo is populated with XUID first, so it doesn't fail out. 
- i think this needs a proper fix/refactor where Autospoofing starts as soon as Game Info is available. But no time atm :-) 