### PR TITLE
Fixed and updated Human Fall Flat

### DIFF
--- a/Events/Data.json
+++ b/Events/Data.json
@@ -31497,7 +31497,7 @@
     }
   },
   "312881568": {
-    "FullySupported": true,
+    "FullySupported": false,
     "Achievements": {
       "1": {
         "Replacement1": {
@@ -31931,595 +31931,451 @@
           "Replacement": "Achievement035"
         }
       },
-      "37": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement036"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement036"
-        }
-      },
-      "38": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement037"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement037"
-        }
-      },
-      "39": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement038"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement038"
-        }
-      },
-      "40": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement039"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement039"
-        }
-      },
-      "41": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement040"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement040"
-        }
-      },
-      "42": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement041"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement041"
-        }
-      },
-      "43": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement042"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement042"
-        }
-      },
-      "44": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement043"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement043"
-        }
-      },
-      "45": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement044"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement044"
-        }
-      },
-      "46": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement045"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement045"
-        }
-      },
-      "47": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement046"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement046"
-        }
-      },
       "48": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement047"
+          "Replacement": "Achievement036"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement047"
+          "Replacement": "Achievement036"
         }
       },
       "49": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement048"
+          "Replacement": "Achievement037"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement048"
+          "Replacement": "Achievement037"
         }
       },
       "50": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement049"
+          "Replacement": "Achievement038"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement049"
+          "Replacement": "Achievement038"
         }
       },
       "51": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement050"
+          "Replacement": "Achievement039"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement050"
+          "Replacement": "Achievement039"
         }
       },
       "52": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement051"
+          "Replacement": "Achievement040"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement051"
+          "Replacement": "Achievement040"
         }
       },
       "53": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement052"
+          "Replacement": "Achievement041"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement052"
+          "Replacement": "Achievement041"
         }
       },
       "54": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement053"
+          "Replacement": "Achievement042"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement053"
+          "Replacement": "Achievement042"
         }
       },
       "55": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement054"
+          "Replacement": "Achievement043"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement054"
+          "Replacement": "Achievement043"
         }
       },
       "56": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement055"
+          "Replacement": "Achievement044"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement055"
+          "Replacement": "Achievement044"
         }
       },
       "57": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement056"
+          "Replacement": "Achievement045"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement056"
+          "Replacement": "Achievement045"
         }
       },
       "58": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement057"
+          "Replacement": "Achievement046"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement057"
+          "Replacement": "Achievement046"
         }
       },
       "59": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement058"
+          "Replacement": "Achievement047"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement058"
+          "Replacement": "Achievement047"
         }
       },
       "60": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement059"
+          "Replacement": "Achievement048"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement059"
+          "Replacement": "Achievement048"
         }
       },
       "61": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement060"
+          "Replacement": "Achievement049"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement060"
+          "Replacement": "Achievement049"
         }
       },
       "62": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement061"
+          "Replacement": "Achievement050"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement061"
+          "Replacement": "Achievement050"
         }
       },
       "63": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement062"
+          "Replacement": "Achievement051"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement062"
+          "Replacement": "Achievement051"
         }
       },
       "64": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement063"
+          "Replacement": "Achievement052"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement063"
+          "Replacement": "Achievement052"
         }
       },
       "65": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement064"
+          "Replacement": "Achievement053"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement064"
+          "Replacement": "Achievement053"
         }
       },
       "66": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement065"
+          "Replacement": "Achievement054"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement065"
+          "Replacement": "Achievement054"
         }
       },
       "67": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement066"
+          "Replacement": "Achievement055"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement066"
+          "Replacement": "Achievement055"
         }
       },
       "68": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement067"
+          "Replacement": "Achievement056"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement067"
+          "Replacement": "Achievement056"
         }
       },
       "69": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement068"
+          "Replacement": "Achievement057"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement068"
+          "Replacement": "Achievement057"
         }
       },
       "70": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement069"
+          "Replacement": "Achievement058"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement069"
+          "Replacement": "Achievement058"
         }
       },
       "71": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement070"
+          "Replacement": "Achievement059"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement070"
+          "Replacement": "Achievement059"
         }
       },
       "72": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement071"
+          "Replacement": "Achievement061"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement071"
+          "Replacement": "Achievement061"
         }
       },
       "73": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement072"
+          "Replacement": "Achievement062"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement072"
+          "Replacement": "Achievement062"
         }
       },
       "74": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement073"
+          "Replacement": "Achievement063"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement073"
+          "Replacement": "Achievement063"
         }
       },
       "75": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement074"
+          "Replacement": "Achievement064"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement074"
+          "Replacement": "Achievement064"
         }
       },
       "76": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement075"
+          "Replacement": "Achievement066"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement075"
+          "Replacement": "Achievement066"
         }
       },
       "77": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement076"
+          "Replacement": "Achievement067"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement076"
+          "Replacement": "Achievement067"
         }
       },
       "78": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement077"
+          "Replacement": "Achievement068"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement077"
+          "Replacement": "Achievement068"
         }
       },
       "79": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement078"
+          "Replacement": "Achievement070"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement078"
+          "Replacement": "Achievement070"
         }
       },
       "80": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement079"
+          "Replacement": "Achievement080"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement079"
+          "Replacement": "Achievement080"
         }
       },
       "81": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement080"
+          "Replacement": "Achievement081"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement080"
+          "Replacement": "Achievement081"
         }
       },
       "82": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement081"
+          "Replacement": "Achievement082"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement081"
+          "Replacement": "Achievement082"
         }
       },
       "83": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement082"
+          "Replacement": "Achievement083"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement082"
+          "Replacement": "Achievement083"
         }
       },
       "84": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement083"
+          "Replacement": "Achievement084"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement083"
+          "Replacement": "Achievement084"
         }
       },
       "85": {
-        "Replacement1": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACETITLE",
-          "Replacement": "Achievement084"
-        },
-        "Replacement2": {
-          "ReplacementType": "Replace",
-          "Target": "REPLACENAME",
-          "Replacement": "Achievement084"
-        }
-      },
-      "87": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
@@ -32543,7 +32399,7 @@
           "Replacement": "Achievement086"
         }
       },
-      "88": {
+      "87": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
@@ -32553,378 +32409,534 @@
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
           "Replacement": "Achievement087"
+        }
+      },
+      "88": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement088"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement088"
         }
       },
       "89": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement088"
+          "Replacement": "Achievement089"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement088"
+          "Replacement": "Achievement089"
         }
       },
       "90": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement089"
+          "Replacement": "Achievement090"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement089"
+          "Replacement": "Achievement090"
         }
       },
       "91": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement090"
+          "Replacement": "Achievement091"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement090"
+          "Replacement": "Achievement091"
         }
       },
       "92": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement091"
+          "Replacement": "Achievement092"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement091"
+          "Replacement": "Achievement092"
         }
       },
       "93": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement092"
+          "Replacement": "Achievement093"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement092"
+          "Replacement": "Achievement093"
         }
       },
       "94": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement093"
+          "Replacement": "Achievement094"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement093"
+          "Replacement": "Achievement094"
         }
       },
       "95": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement094"
+          "Replacement": "Achievement095"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement094"
+          "Replacement": "Achievement095"
         }
       },
       "96": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement095"
+          "Replacement": "Achievement096"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement095"
+          "Replacement": "Achievement096"
         }
       },
       "97": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement096"
+          "Replacement": "Achievement097"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement096"
+          "Replacement": "Achievement097"
         }
       },
       "98": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement097"
+          "Replacement": "Achievement098"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement097"
+          "Replacement": "Achievement098"
         }
       },
       "99": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement098"
+          "Replacement": "Achievement099"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement098"
+          "Replacement": "Achievement099"
         }
       },
       "100": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement099"
+          "Replacement": "Achievement100"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement099"
+          "Replacement": "Achievement100"
         }
       },
       "101": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement100"
+          "Replacement": "Achievement101"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement100"
+          "Replacement": "Achievement101"
         }
       },
       "102": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement101"
+          "Replacement": "Achievement102"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement101"
+          "Replacement": "Achievement102"
         }
       },
       "103": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement102"
+          "Replacement": "Achievement103"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement102"
+          "Replacement": "Achievement103"
         }
       },
       "104": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement103"
+          "Replacement": "Achievement104"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement103"
+          "Replacement": "Achievement104"
         }
       },
       "105": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement104"
+          "Replacement": "Achievement105"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement104"
+          "Replacement": "Achievement105"
         }
       },
       "106": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement105"
+          "Replacement": "Achievement106"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement105"
+          "Replacement": "Achievement106"
         }
       },
       "107": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement106"
+          "Replacement": "Achievement107"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement106"
+          "Replacement": "Achievement107"
         }
       },
       "108": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement107"
+          "Replacement": "Achievement108"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement107"
+          "Replacement": "Achievement108"
         }
       },
       "109": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement108"
+          "Replacement": "Achievement109"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement108"
+          "Replacement": "Achievement109"
         }
       },
       "110": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement109"
+          "Replacement": "Achievement110"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement109"
+          "Replacement": "Achievement110"
         }
       },
       "111": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement110"
+          "Replacement": "Achievement111"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement110"
+          "Replacement": "Achievement111"
         }
       },
       "112": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement111"
+          "Replacement": "Achievement112"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement111"
+          "Replacement": "Achievement112"
         }
       },
       "113": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement112"
+          "Replacement": "Achievement113"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement112"
+          "Replacement": "Achievement113"
         }
       },
       "114": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement113"
+          "Replacement": "Achievement114"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement113"
+          "Replacement": "Achievement114"
         }
       },
       "115": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement114"
+          "Replacement": "Achievement115"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement114"
+          "Replacement": "Achievement115"
         }
       },
       "116": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement115"
+          "Replacement": "Achievement116"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement115"
+          "Replacement": "Achievement116"
         }
       },
       "117": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement116"
+          "Replacement": "Achievement117"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement116"
+          "Replacement": "Achievement117"
         }
       },
       "118": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement117"
+          "Replacement": "Achievement118"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement117"
+          "Replacement": "Achievement118"
         }
       },
       "119": {
         "Replacement1": {
           "ReplacementType": "Replace",
           "Target": "REPLACETITLE",
-          "Replacement": "Achievement118"
+          "Replacement": "Achievement119"
         },
         "Replacement2": {
           "ReplacementType": "Replace",
           "Target": "REPLACENAME",
-          "Replacement": "Achievement118"
+          "Replacement": "Achievement119"
+        }
+      },
+      "120": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement120"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement120"
+        }
+      },
+      "121": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement121"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement121"
+        }
+      },
+      "122": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement122"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement122"
+        }
+      },
+      "123": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement123"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement123"
+        }
+      },
+      "124": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement124"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement124"
+        }
+      },
+      "125": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement125"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement125"
+        }
+      },
+      "126": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement126"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement126"
+        }
+      },
+      "127": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement127"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement127"
+        }
+      },
+      "128": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement128"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement128"
+        }
+      },
+      "129": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement129"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement129"
+        }
+      },
+      "130": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement130"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement130"
+        }
+      },
+      "131": {
+        "Replacement1": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACETITLE",
+          "Replacement": "Achievement131"
+        },
+        "Replacement2": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACENAME",
+          "Replacement": "Achievement131"
         }
       }
     }


### PR DESCRIPTION
Many of the IDs were wrong and unlocked different achievements. Fixed them all.

Achievements 37 - 47 are incremental achievements and require a total rebuild. (If anyone in the future want to do it.) 
Removed them and changed "Fully supported" to false.

Newer DLC achievements only require a simple ID-change which I have also added.