### PR TITLE
ID fix for ReCore

### DIFF
--- a/Events/Data.json
+++ b/Events/Data.json
@@ -24875,6 +24875,13 @@
           "Replacement": "37"
         }
       },
+      "32": {
+        "CriteriaReplacement": {
+          "ReplacementType": "Replace",
+          "Target": "REPLACECRITERIA",
+          "Replacement": "0"
+        }
+      },
       "33": {
         "CriteriaReplacement": {
           "ReplacementType": "Replace",


### PR DESCRIPTION
Added support for achievement ID 32 "Love you, Kiddo" in ReCore.