### PR TITLE
fix: replace deprecated set-output command with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/Build-Pre-Release.yml
+++ b/.github/workflows/Build-Pre-Release.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Get latest commit hash
       id: get-hash
-      run: echo "::set-output name=hash::$(git rev-parse HEAD)"
+      run: echo "hash=$(git rev-parse HEAD)" >> $env:GITHUB_OUTPUT
 
     - name: Replace ToolVersion with commit hash
       run: |


### PR DESCRIPTION
## Fix: Replace deprecated set-output command

GitHub has deprecated [`::set-output`](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/) and it will stop working. This PR replaces it with `$GITHUB_OUTPUT`.

### Changes
- Replace `::set-output` with `$env:GITHUB_OUTPUT`
