### PR TITLE
Add warning on Spoofer page when OAuth login is enabled

### DIFF
--- a/XAU/ViewModels/Pages/MiscViewModel.cs
+++ b/XAU/ViewModels/Pages/MiscViewModel.cs
@@ -34,9 +34,6 @@ namespace XAU.ViewModels.Pages
         {
             if (!IsInitialized && HomeViewModel.InitComplete)
                 InitializeViewModel();
-            OAuthWarningVisibility = (HomeViewModel.Settings?.OAuthLogin ?? false)
-                ? System.Windows.Visibility.Visible
-                : System.Windows.Visibility.Collapsed;
         }
 
         public void OnNavigatedFrom()
@@ -59,7 +56,6 @@ namespace XAU.ViewModels.Pages
         [ObservableProperty] private string _gameGamerscore = "Gamerscore: ?/?";
         [ObservableProperty] private string? _gameImage = "pack://application:,,,/Assets/cirno.png";
         [ObservableProperty] private string _gameTime = "Time Played: ";
-        [ObservableProperty] private System.Windows.Visibility _oAuthWarningVisibility = System.Windows.Visibility.Collapsed;
         [ObservableProperty] private bool _isInitialized = false;
         [ObservableProperty] private string _currentSpoofingID = "";
         [ObservableProperty] private string _newSpoofingID = "";
@@ -93,6 +89,15 @@ namespace XAU.ViewModels.Pages
                 await _xboxRestAPI.Value.StopHeartbeatAsync(HomeViewModel.XUIDOnly);
                 return;
             }
+
+            if (HomeViewModel.Settings?.OAuthLogin ?? false)
+            {
+                _snackbarService.Show("Warning: OAuth Token Limitation",
+                    "OAuth tokens lack the scope to register presence. The timer will count up locally but will not reach Xbox Live servers.",
+                    ControlAppearance.Caution,
+                    new SymbolIcon(SymbolRegular.Warning24), _snackbarDuration);
+            }
+
             HomeViewModel.SpoofedTitleID = NewSpoofingID;
 
             if (HomeViewModel.SpoofingStatus == 2)

--- a/XAU/ViewModels/Pages/MiscViewModel.cs
+++ b/XAU/ViewModels/Pages/MiscViewModel.cs
@@ -34,6 +34,9 @@ namespace XAU.ViewModels.Pages
         {
             if (!IsInitialized && HomeViewModel.InitComplete)
                 InitializeViewModel();
+            OAuthWarningVisibility = (HomeViewModel.Settings?.OAuthLogin ?? false)
+                ? System.Windows.Visibility.Visible
+                : System.Windows.Visibility.Collapsed;
         }
 
         public void OnNavigatedFrom()
@@ -56,6 +59,7 @@ namespace XAU.ViewModels.Pages
         [ObservableProperty] private string _gameGamerscore = "Gamerscore: ?/?";
         [ObservableProperty] private string? _gameImage = "pack://application:,,,/Assets/cirno.png";
         [ObservableProperty] private string _gameTime = "Time Played: ";
+        [ObservableProperty] private System.Windows.Visibility _oAuthWarningVisibility = System.Windows.Visibility.Collapsed;
         [ObservableProperty] private bool _isInitialized = false;
         [ObservableProperty] private string _currentSpoofingID = "";
         [ObservableProperty] private string _newSpoofingID = "";

--- a/XAU/Views/Pages/MiscPage.xaml
+++ b/XAU/Views/Pages/MiscPage.xaml
@@ -26,16 +26,31 @@
                         <TextBlock Text="Spoofer" />
                     </StackPanel>
                 </TabItem.Header>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Margin="0" Text="{Binding ViewModel.SpoofingText}" />
+                <DockPanel>
+                    <Border
+                        DockPanel.Dock="Top"
+                        Margin="0,0,0,10"
+                        Padding="12,8"
+                        Background="#332B1B00"
+                        BorderBrush="#FFB800"
+                        BorderThickness="1"
+                        CornerRadius="4"
+                        Visibility="{Binding ViewModel.OAuthWarningVisibility}">
+                        <TextBlock
+                            FontSize="12"
+                            TextWrapping="Wrap"
+                            Text="OAuth login is enabled. OAuth tokens do not have sufficient scope to register presence or time played with Xbox Live. The spoofing timer will count up locally, but the change will not reach Microsoft's servers. To use this feature, disable OAuth in Settings and sign in via the Xbox app, or paste a manually obtained XAUTH token." />
+                    </Border>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Margin="0" Text="{Binding ViewModel.SpoofingText}" />
                     <Button
                         Grid.Row="0"
                         Grid.Column="1"
@@ -115,7 +130,8 @@
                         VerticalAlignment="Top"
                         Content="{Binding ViewModel.GameTime}" />
 
-                </Grid>
+                    </Grid>
+                </DockPanel>
             </TabItem>
 
             <TabItem>

--- a/XAU/Views/Pages/MiscPage.xaml
+++ b/XAU/Views/Pages/MiscPage.xaml
@@ -26,31 +26,16 @@
                         <TextBlock Text="Spoofer" />
                     </StackPanel>
                 </TabItem.Header>
-                <DockPanel>
-                    <Border
-                        DockPanel.Dock="Top"
-                        Margin="0,0,0,10"
-                        Padding="12,8"
-                        Background="#332B1B00"
-                        BorderBrush="#FFB800"
-                        BorderThickness="1"
-                        CornerRadius="4"
-                        Visibility="{Binding ViewModel.OAuthWarningVisibility}">
-                        <TextBlock
-                            FontSize="12"
-                            TextWrapping="Wrap"
-                            Text="OAuth login is enabled. OAuth tokens do not have sufficient scope to register presence or time played with Xbox Live. The spoofing timer will count up locally, but the change will not reach Microsoft's servers. To use this feature, disable OAuth in Settings and sign in via the Xbox app, or paste a manually obtained XAUTH token." />
-                    </Border>
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Margin="0" Text="{Binding ViewModel.SpoofingText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Margin="0" Text="{Binding ViewModel.SpoofingText}" />
                     <Button
                         Grid.Row="0"
                         Grid.Column="1"
@@ -130,8 +115,7 @@
                         VerticalAlignment="Top"
                         Content="{Binding ViewModel.GameTime}" />
 
-                    </Grid>
-                </DockPanel>
+                </Grid>
             </TabItem>
 
             <TabItem>


### PR DESCRIPTION
## Summary
- Adds a warning banner to the Spoofer page that is only shown when `Settings.OAuthLogin == true`.

## Why
OAuth-issued XAUTH tokens do not have sufficient scope to POST to `presence-heartbeat.xboxlive.com/users/xuid(...)/devices/current/` — the request returns HTTP 403 Forbidden. Because `SendHeartbeatAsync` discards the HTTP response, OAuth users currently have no way to tell the spoofer is silently failing: the local stopwatch counts up regardless. Per discussion with the maintainer, OAuth token scope does not permit presence writes, and memory-scan login or a manually-supplied XAUTH is required for spoofing to actually land server-side. This PR surfaces that limitation in the UI so OAuth users aren't left wondering why their time-played never moves.

## What changed
- `XAU/Views/Pages/MiscPage.xaml`: wrapped the Spoofer tab's existing `Grid` in a `DockPanel` and added a `Border` with a warning message docked to the top. No existing child of the Spoofer `Grid` was modified, so layout is preserved.
- `XAU/ViewModels/Pages/MiscViewModel.cs`: added an `OAuthWarningVisibility` observable property (`System.Windows.Visibility`), updated from `HomeViewModel.Settings.OAuthLogin` in `OnNavigatedTo` so the banner reflects the current setting every time the user navigates to the Misc page.

## Test plan
- [x] `dotnet build XAU/XAU.csproj -c Release -p:Platform=x64 -p:EnableWindowsTargeting=true` — 0 errors
- [ ] Banner appears on the Spoofer page when `OAuthLogin` is enabled in Settings
- [ ] Banner disappears when `OAuthLogin` is disabled (refresh happens on navigation to the Misc page)
- [ ] Existing Spoofer tab layout is unchanged when the banner is collapsed