### PR TITLE
fix mislabeled auto spoofer setting description

### DIFF
--- a/XAU/Views/Pages/SettingsPage.xaml
+++ b/XAU/Views/Pages/SettingsPage.xaml
@@ -61,7 +61,7 @@
                     <ui:TextBlock
                         Grid.Row="1"
                         Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
-                        Text="Hide your profile info in the home page. Requires a refresh if info is already grabbed."
+                        Text="Automatically spoofs the title ID when you open a game's achievements page."
                         TextWrapping="WrapWithOverflow" />
                 </Grid>
             </ui:CardControl.Header>


### PR DESCRIPTION
The description under "Enable Auto Spoofer" on the Settings page was a copy of the Privacy Mode blurb about hiding profile info on the home page, which has nothing to do with what the toggle actually does.

Replace it with an accurate one-liner describing the real behavior: auto-spoofing the title ID when you open a game's achievements page (per `AchievementsViewModel.OnNavigatedTo` / `LoadGame` calling `SpoofGame()` when `AutoSpooferEnabled` is true).

Text-only change in `XAU/Views/Pages/SettingsPage.xaml` — no code or binding changes.